### PR TITLE
fixed header position by name

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/data/Block.java
+++ b/src/main/java/com/github/housepower/jdbc/data/Block.java
@@ -33,7 +33,7 @@ public class Block {
 
         nameWithPosition = new HashMap<String, Integer>();
         for (int i = 0; i < columns.length; i++) {
-            nameWithPosition.put(columns[i].name(), i);
+            nameWithPosition.put(columns[i].name(), i+1);
         }
     }
 


### PR DESCRIPTION
unfortunately, nameWithPosition has wrong index number, therefore getPositionByName/findColumn return wrong position and as result - getString/getInt by column name return SQLException - wrong field == wrong type .