### PR TITLE
register driver with ServiceLoader

### DIFF
--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+com.github.housepower.jdbc.ClickHouseDriver


### PR DESCRIPTION
This enables the driver to work without explicit call to `Class.forName()`