### PR TITLE
Support streaming resultset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                     <fork>true</fork>
                 </configuration>
             </plugin>

--- a/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
+++ b/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
@@ -119,18 +119,8 @@ public class ClickHouseConnection extends SQLConnection {
         PhysicalConnection connection = getHealthyPhysicalConnection();
 
         connection.sendQuery(query, atomicInfo.get().client(), configure.settings());
-        List<RequestOrResponse> data = new ArrayList<RequestOrResponse>();
 
-        while (true) {
-            RequestOrResponse response =
-                connection.receiveResponse(configure.queryTimeout(), atomicInfo.get().server());
-
-            if (response instanceof EOFStreamResponse) {
-                return new QueryResponse(data);
-            }
-
-            data.add(response);
-        }
+        return new QueryResponse(() -> connection.receiveResponse(configure.queryTimeout(), atomicInfo.get().server()));
     }
 
     public Integer sendInsertRequest(final String insertQuery, final InputFormat input) throws SQLException {

--- a/src/main/java/com/github/housepower/jdbc/ClickHouseResultSet.java
+++ b/src/main/java/com/github/housepower/jdbc/ClickHouseResultSet.java
@@ -2,6 +2,7 @@ package com.github.housepower.jdbc;
 
 import com.github.housepower.jdbc.data.Block;
 import com.github.housepower.jdbc.data.Column;
+import com.github.housepower.jdbc.misc.CheckedIterator;
 import com.github.housepower.jdbc.misc.Validate;
 import com.github.housepower.jdbc.protocol.DataResponse;
 import com.github.housepower.jdbc.statement.ClickHouseStatement;
@@ -29,9 +30,9 @@ public class ClickHouseResultSet extends SQLResultSet {
 
     private final Block header;
     private final ClickHouseStatement statement;
-    private final Iterator<DataResponse> iterator;
+    private final CheckedIterator<DataResponse, SQLException> iterator;
 
-    public ClickHouseResultSet(Block header, Iterator<DataResponse> iterator, ClickHouseStatement statement) {
+    public ClickHouseResultSet(Block header, CheckedIterator<DataResponse, SQLException> iterator, ClickHouseStatement statement) {
         this.header = header;
         this.iterator = iterator;
         this.statement = statement;
@@ -244,7 +245,7 @@ public class ClickHouseResultSet extends SQLResultSet {
         return ++row < current.rows() || (row = 0) < (current = fetchBlock()).rows();
     }
 
-    private Block fetchBlock() {
+    private Block fetchBlock() throws SQLException {
         while (iterator.hasNext()) {
             DataResponse next = iterator.next();
             if (next.block().rows() > 0) {

--- a/src/main/java/com/github/housepower/jdbc/misc/CheckedIterator.java
+++ b/src/main/java/com/github/housepower/jdbc/misc/CheckedIterator.java
@@ -1,0 +1,12 @@
+package com.github.housepower.jdbc.misc;
+
+/**
+ * Copyright (C) 2018 SpectX
+ * Created by Lauri Nõmme
+ * 12.12.2018 16:11
+ */
+public interface CheckedIterator<T, E extends Throwable> {
+    boolean hasNext() throws E;
+
+    T next() throws E;
+}

--- a/src/main/java/com/github/housepower/jdbc/misc/CheckedSupplier.java
+++ b/src/main/java/com/github/housepower/jdbc/misc/CheckedSupplier.java
@@ -1,0 +1,10 @@
+package com.github.housepower.jdbc.misc;
+
+/**
+ * Copyright (C) 2018 SpectX
+ * Created by Lauri Nõmme
+ * 12.12.2018 16:04
+ */
+public interface CheckedSupplier<R, E extends Throwable> {
+    R get() throws E;
+}

--- a/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
+++ b/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
@@ -44,7 +44,7 @@ public class ClickHouseStatement extends SQLStatement {
             return connection.sendInsertRequest(insertQuery, new ValuesInputFormat(matcher.end() - 1, query));
         }
         QueryResponse response = connection.sendQueryRequest(query);
-        lastResultSet = new ClickHouseResultSet(response.header(), response.data().iterator(), this);
+        lastResultSet = new ClickHouseResultSet(response.header(), response.data().get(), this);
         return 0;
     }
 

--- a/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
+++ b/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
@@ -6,10 +6,7 @@ import com.github.housepower.jdbc.settings.SettingKey;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.Properties;
 
 public class ConnectionParamITest {
@@ -19,7 +16,12 @@ public class ConnectionParamITest {
         Class.forName("com.github.housepower.jdbc.ClickHouseDriver");
         Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1?max_rows_to_read=1&connect_timeout=10");
         Statement statement = connection.createStatement();
-        statement.execute("SELECT 1 UNION ALL SELECT 2");
+        ResultSet rs = statement.executeQuery("SELECT 1 UNION ALL SELECT 2");
+        int rowsRead = 0;
+        while (rs.next()) {
+            ++rowsRead;
+        }
+        Assert.assertEquals(1, rowsRead); // not reached
     }
 
     @Test


### PR DESCRIPTION
Current solution accumulates all rows in resultset, making it impossible to process large resultsets in streaming fashion.

Change processing such that resultset accumulates a single row.

Is it okay to change language level to Java 8?