### PR TITLE
Do url check before create connection

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/NonRegisterDriver.java
+++ b/src/main/java/com/github/housepower/jdbc/NonRegisterDriver.java
@@ -19,6 +19,9 @@ public class NonRegisterDriver implements Driver {
     }
 
     public Connection connect(String url, Properties properties) throws SQLException {
+        if (!this.acceptsURL(url)) {
+            return null;
+        }
         ClickHouseConfig configure = new ClickHouseConfig(url, properties);
         return ClickHouseConnection.createClickHouseConnection(configure);
     }

--- a/src/test/java/com/github/housepower/jdbc/ClickhouseDriverRegisterTest.java
+++ b/src/test/java/com/github/housepower/jdbc/ClickhouseDriverRegisterTest.java
@@ -1,11 +1,9 @@
 package com.github.housepower.jdbc;
 
+import com.github.housepower.jdbc.tool.EmbeddedDriver;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.DriverManager;
 import java.util.Properties;
 
@@ -18,15 +16,11 @@ public class ClickhouseDriverRegisterTest {
         Properties properties = new Properties();
         properties.setProperty("user", "user");
         properties.setProperty("password", "password");
-        String mockedUrl = "jdbc:mock://127.0.0.1:" + SERVER_PORT;
-        Driver mockedDriver = Mockito.mock(Driver.class);
-        Connection mockedConnection = Mockito.mock(Connection.class);
-        Mockito.when(mockedDriver.acceptsURL(mockedUrl)).thenReturn(true);
-        Mockito.when(mockedDriver.connect(mockedUrl, properties)).thenReturn(mockedConnection);
+        String mockedUrl = EmbeddedDriver.EMBEDDED_DRIVER_PREFIX + "//127.0.0.1:" + SERVER_PORT;
 
         Class.forName("com.github.housepower.jdbc.ClickHouseDriver");
-        DriverManager.registerDriver(mockedDriver);
-        Assert.assertEquals(mockedConnection, DriverManager.getConnection(mockedUrl, properties));
+        DriverManager.registerDriver(new EmbeddedDriver());
+        Assert.assertEquals(EmbeddedDriver.MOCKED_CONNECTION, DriverManager.getConnection(mockedUrl, properties));
     }
 
 }

--- a/src/test/java/com/github/housepower/jdbc/ClickhouseDriverRegisterTest.java
+++ b/src/test/java/com/github/housepower/jdbc/ClickhouseDriverRegisterTest.java
@@ -1,0 +1,32 @@
+package com.github.housepower.jdbc;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Properties;
+
+public class ClickhouseDriverRegisterTest {
+
+    private static final int SERVER_PORT = Integer.valueOf(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
+
+    @Test
+    public void successfullyCreateConnection() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("user", "user");
+        properties.setProperty("password", "password");
+        String mockedUrl = "jdbc:mock://127.0.0.1:" + SERVER_PORT;
+        Driver mockedDriver = Mockito.mock(Driver.class);
+        Connection mockedConnection = Mockito.mock(Connection.class);
+        Mockito.when(mockedDriver.acceptsURL(mockedUrl)).thenReturn(true);
+        Mockito.when(mockedDriver.connect(mockedUrl, properties)).thenReturn(mockedConnection);
+
+        Class.forName("com.github.housepower.jdbc.ClickHouseDriver");
+        DriverManager.registerDriver(mockedDriver);
+        Assert.assertEquals(mockedConnection, DriverManager.getConnection(mockedUrl, properties));
+    }
+
+}

--- a/src/test/java/com/github/housepower/jdbc/tool/EmbeddedDriver.java
+++ b/src/test/java/com/github/housepower/jdbc/tool/EmbeddedDriver.java
@@ -1,0 +1,48 @@
+package com.github.housepower.jdbc.tool;
+
+import org.mockito.Mockito;
+
+import java.sql.*;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class EmbeddedDriver implements Driver {
+
+    public static final Connection MOCKED_CONNECTION = Mockito.mock(Connection.class);
+    public static final String EMBEDDED_DRIVER_PREFIX = "jdbc:embedded:";
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        return MOCKED_CONNECTION;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return url.startsWith(EMBEDDED_DRIVER_PREFIX);
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+}


### PR DESCRIPTION
* avoid creating error connection when multi-drivers were registered

```java
Class.forName("com.github.housepower.jdbc.ClickHouseDriver");
Class.forName("org.apache.phoenix.jdbc.PhoenixDriver");
Connection conn = DriverManager.getConnection("jdbc:phoenix:quorums")
println(conn.getClass() == com.github.housepower.jdbc.ClickHouseConnection.class);
// true
```