### PR TITLE
compat with Flink-JDBC

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
+++ b/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
@@ -73,6 +73,11 @@ public class ClickHouseConnection extends SQLConnection {
     }
 
     @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return this.prepareStatement(sql);
+    }
+
+    @Override
     public void setClientInfo(Properties properties) throws SQLClientInfoException {
         configure.parseJDBCProperties(properties);
     }

--- a/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
+++ b/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
@@ -49,6 +49,10 @@ public class ClickHouseStatement extends SQLStatement {
     }
 
     @Override
+    public void setFetchSize(int rows) throws SQLException {
+    }
+
+    @Override
     public void close() throws SQLException {
     }
 


### PR DESCRIPTION
Fix exceptions when using flink jdbc.

Flink will call setFetchSize & prepareStatement function when using sink function.

The default implement will cause exception, so i rewrite it with empty implementation to compat flink jdbc sink function.