### PR TITLE
Clear error message for fetching a column when it doesn't exist

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/data/Block.java
+++ b/src/main/java/com/github/housepower/jdbc/data/Block.java
@@ -96,7 +96,7 @@ public class Block {
     }
 
     public int getPositionByName(String name) throws SQLException {
-        Validate.isTrue(nameWithPosition.containsKey(name));
+        Validate.isTrue(nameWithPosition.containsKey(name),"Column '" + name + "' does not exist");
         return nameWithPosition.get(name);
     }
 


### PR DESCRIPTION
Put in a clear error message when validation fails if the column named doesn't exist in the result set.