### PR TITLE
fix PrepareInsertStatement Problem

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/ConnectionState.java
+++ b/src/main/java/com/github/housepower/jdbc/ConnectionState.java
@@ -1,0 +1,6 @@
+package com.github.housepower.jdbc;
+
+public enum ConnectionState {
+
+    IDLE, WAITING_INSERT
+}

--- a/src/test/java/com/github/housepower/jdbc/BatchInsertITest.java
+++ b/src/test/java/com/github/housepower/jdbc/BatchInsertITest.java
@@ -33,12 +33,52 @@ public class BatchInsertITest extends AbstractITest {
                 Assert.assertEquals(preparedStatement.executeBatch().length, Byte.MAX_VALUE);
 
                 ResultSet rs = statement.executeQuery("select * from test");
-
-                for (int i = 0; i < Byte.MAX_VALUE && rs.next(); i ++) {
+                boolean hasResult = false;
+                for (int i = 0; i < Byte.MAX_VALUE && rs.next(); i++) {
+                    hasResult = true;
                     Assert.assertEquals(rs.getByte(1), i);
                     Assert.assertEquals(rs.getByte(2), 1);
                     Assert.assertEquals(rs.getString(3), "Zhang San" + i);
                 }
+                Assert.assertTrue(hasResult);
+            }
+
+        });
+
+    }
+
+    @Test
+    public void successfullyMultipleBatchInsert() throws Exception {
+        withNewConnection(new WithConnection() {
+            @Override
+            public void apply(Connection connection) throws Exception {
+                Statement statement = connection.createStatement();
+
+                statement.execute("DROP TABLE IF EXISTS test");
+                statement.execute("CREATE TABLE test(id Int8, age UInt8, name String)ENGINE=Log");
+                PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO test VALUES(?, 1, ?)");
+
+                int insertBatchSize = 100;
+
+                for (int i = 0; i < insertBatchSize; i++) {
+                    preparedStatement.setByte(1, (byte) i);
+                    preparedStatement.setString(2, "Zhang San" + i);
+                    preparedStatement.addBatch();
+                }
+
+                Assert.assertEquals(preparedStatement.executeBatch().length, insertBatchSize);
+
+                for (int i = 0; i < insertBatchSize; i++) {
+                    preparedStatement.setByte(1, (byte) i);
+                    preparedStatement.setString(2, "Zhang San" + i);
+                    preparedStatement.addBatch();
+                }
+
+                Assert.assertEquals(preparedStatement.executeBatch().length, insertBatchSize);
+
+                ResultSet rs = statement.executeQuery("select count(1) from test");
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(2 * insertBatchSize, rs.getInt(1));
             }
 
         });
@@ -71,7 +111,7 @@ public class BatchInsertITest extends AbstractITest {
                 Assert.assertEquals(preparedStatement.executeBatch().length, Byte.MAX_VALUE);
 
                 ResultSet rs = statement.executeQuery("select * from test");
-                while(rs.next()) {
+                while (rs.next()) {
                     Assert.assertArrayEquals((Object[]) rs.getArray(1).getArray(), array.toArray());
                     Assert.assertArrayEquals((Object[]) rs.getArray(2).getArray(), array2.toArray());
                 }
@@ -92,7 +132,7 @@ public class BatchInsertITest extends AbstractITest {
                 PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO test VALUES(?)");
 
                 // 2018-07-01 00:00:00  Asia/Shanghai
-                long time = 1530374400 ;
+                long time = 1530374400;
                 long insertTime = time;
                 for (int i = 0; i < 24; i++) {
                     preparedStatement.setTimestamp(1, new Timestamp(insertTime * 1000));
@@ -106,7 +146,7 @@ public class BatchInsertITest extends AbstractITest {
                 ResultSet rs = statement.executeQuery("SELECT  * FROM test ORDER BY time ASC");
                 while (rs.next()) {
                     Assert.assertEquals(rs.getTimestamp(1).getTime(),
-                                        selectTime * 1000);
+                            selectTime * 1000);
                     selectTime += 3600;
                 }
             }


### PR DESCRIPTION
In flink_jdbc , a PreapredInsertStatement will be used more than once.

This pr fix the problem when executeBatch many times.

And I add a state property in ClickhouseConnection,  to ensure the query operation can be execute normally.
