### PR TITLE
Fix problems which makes the JDBC library not platform independent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,9 @@
     <properties>
         <ClickHousePort>9000</ClickHousePort>
         <ClickHouseHTTPPort>8123</ClickHouseHTTPPort>
-
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
 
@@ -172,10 +174,35 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
                     <fork>true</fork>
                 </configuration>
+            </plugin>
+            <plugin>
+              <groupId>de.thetaphi</groupId>
+              <artifactId>forbiddenapis</artifactId>
+              <version>3.0.1</version>
+              <configuration>
+                <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                <bundledSignatures>
+                  <bundledSignature>jdk-unsafe</bundledSignature>
+                  <!-- fix this (some tests use deprecated methods from Java 8, this should not be done):
+                  <bundledSignature>jdk-deprecated</bundledSignature>
+                  -->
+                  <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                  <bundledSignature>jdk-non-portable</bundledSignature>
+                  <!-- don't allow unsafe reflective access: -->
+                  <bundledSignature>jdk-reflection</bundledSignature>
+                </bundledSignatures>
+                <excludes>**/*jmhTest.class</excludes>
+              </configuration>
+              <executions>
+                <execution>
+                  <goals>
+                    <goal>check</goal>
+                    <goal>testCheck</goal>
+                  </goals>
+                </execution>
+              </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
+++ b/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
@@ -22,6 +22,7 @@ import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -182,7 +183,7 @@ public class ClickHouseConnection extends SQLConnection {
     private static QueryRequest.ClientInfo clientInfo(PhysicalConnection physical, ClickHouseConfig configure) throws SQLException {
         Validate.isTrue(physical.address() instanceof InetSocketAddress);
         InetSocketAddress address = (InetSocketAddress) physical.address();
-        String clientName = String.format("%s %s", ClickHouseDefines.NAME, "client");
+        String clientName = String.format(Locale.ROOT, "%s %s", ClickHouseDefines.NAME, "client");
         String initialAddress = "[::ffff:127.0.0.1]:0";
         return new QueryRequest.ClientInfo(initialAddress, address.getHostName(), clientName);
     }

--- a/src/main/java/com/github/housepower/jdbc/data/type/DataTypeDate.java
+++ b/src/main/java/com/github/housepower/jdbc/data/type/DataTypeDate.java
@@ -16,12 +16,13 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 public class DataTypeDate implements IDataType {
 
     private static final Date DEFAULT_VALUE = new Date(0);
     private final DateTimeZone dateTimeZone;
-    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
 
 
     public DataTypeDate(PhysicalInfo.ServerInfo serverInfo) {
@@ -94,7 +95,7 @@ public class DataTypeDate implements IDataType {
         int day = lexer.numberLiteral().intValue();
         Validate.isTrue(lexer.character() == '\'');
 
-        String timeStr = String.format("%04d-%02d-%02d", year, month, day);
+        String timeStr = String.format(Locale.ROOT, "%04d-%02d-%02d", year, month, day);
         try {
             java.util.Date date = dateFormat.parse(timeStr);
             return new Date(date.getTime());

--- a/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime.java
+++ b/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime.java
@@ -18,11 +18,12 @@ import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 public class DataTypeDateTime implements IDataType {
 
     private static final Timestamp DEFAULT_VALUE = new Timestamp(0);
-    private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
 
     private final String name;
 
@@ -77,7 +78,7 @@ public class DataTypeDateTime implements IDataType {
         int seconds = lexer.numberLiteral().intValue();
         Validate.isTrue(lexer.character() == '\'');
 
-        String timeStr = String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hours, minutes, seconds);
+        String timeStr = String.format(Locale.ROOT, "%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hours, minutes, seconds);
 
         try {
             Date date = dateTimeFormat.parse(timeStr);

--- a/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
+++ b/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public class DataTypeDateTime64 implements IDataType {
@@ -23,7 +24,7 @@ public class DataTypeDateTime64 implements IDataType {
     public static final Timestamp DEFAULT_VALUE = new Timestamp(0);
     public static final int NANOS_IN_SECOND = 1_000_000_000;
     public static final int MILLIS_IN_SECOND = 1000;
-    private final DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS");
+    private final DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS", Locale.ROOT);
     private final String name;
     private final TimeZone timeZone;
 
@@ -109,7 +110,7 @@ public class DataTypeDateTime64 implements IDataType {
         Validate.isTrue(lexer.character() == '\'');
         Validate.isTrue(lexer.character() == ')');
 
-        String timeStr = String.format("%04d-%02d-%02d %02d:%02d:%02d.%09d", year, month, day, hours, minutes, seconds, nanos);
+        String timeStr = String.format(Locale.ROOT, "%04d-%02d-%02d %02d:%02d:%02d.%09d", year, month, day, hours, minutes, seconds, nanos);
         LocalDateTime dateTime = LocalDateTime.parse(timeStr, dateTimeFormat);
         return Timestamp.valueOf(dateTime);
     }

--- a/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDecimal.java
+++ b/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDecimal.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Locale;
 
 public class DataTypeDecimal implements IDataType {
 
@@ -36,7 +37,7 @@ public class DataTypeDecimal implements IDataType {
         } else if (this.precision <= 18) {
             this.nobits = 64;
         } else {
-            throw new IllegalArgumentException(String.format("Precision[%d] is out of boundary.", precision));
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Precision[%d] is out of boundary.", precision));
         }
     }
 
@@ -92,7 +93,7 @@ public class DataTypeDecimal implements IDataType {
                 break;
             }
             default: {
-                throw new RuntimeException(String.format("Unknown precision[%d] & scale[%d]", precision, scale));
+                throw new RuntimeException(String.format(Locale.ENGLISH, "Unknown precision[%d] & scale[%d]", precision, scale));
             }
         }
     }
@@ -114,7 +115,7 @@ public class DataTypeDecimal implements IDataType {
                 break;
             }
             default: {
-                throw new RuntimeException(String.format("Unknown precision[%d] & scale[%d]", precision, scale));
+                throw new RuntimeException(String.format(Locale.ENGLISH, "Unknown precision[%d] & scale[%d]", precision, scale));
             }
         }
         value = value.setScale(scale, RoundingMode.HALF_UP);

--- a/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeFixedString.java
+++ b/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeFixedString.java
@@ -8,6 +8,7 @@ import com.github.housepower.jdbc.serializer.BinaryDeserializer;
 import com.github.housepower.jdbc.serializer.BinarySerializer;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -61,7 +62,7 @@ public class DataTypeFixedString implements IDataType {
     @Override
     public void serializeBinary(Object data, BinarySerializer serializer)
         throws SQLException, IOException {
-        writeBytes(((String) data).getBytes(), serializer);
+        writeBytes(((String) data).getBytes(StandardCharsets.UTF_8), serializer);
     }
 
     private void writeBytes(byte[] bs, BinarySerializer serializer)
@@ -82,7 +83,7 @@ public class DataTypeFixedString implements IDataType {
     @Override
     public Object deserializeBinary(BinaryDeserializer deserializer)
         throws SQLException, IOException {
-        return new String(deserializer.readBytes(n));
+        return new String(deserializer.readBytes(n), StandardCharsets.UTF_8);
     }
 
     @Override
@@ -90,7 +91,7 @@ public class DataTypeFixedString implements IDataType {
         throws SQLException, IOException {
         String[] data = new String[rows];
         for (int row = 0; row < rows; row++) {
-            data[row] = new String(deserializer.readBytes(n));
+            data[row] = new String(deserializer.readBytes(n), StandardCharsets.UTF_8);
         }
         return data;
     }

--- a/src/main/java/com/github/housepower/jdbc/serializer/BinaryDeserializer.java
+++ b/src/main/java/com/github/housepower/jdbc/serializer/BinaryDeserializer.java
@@ -7,6 +7,7 @@ import com.github.housepower.jdbc.misc.Container;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 public class BinaryDeserializer {
 
@@ -53,7 +54,7 @@ public class BinaryDeserializer {
 
     public String readStringBinary() throws IOException {
         byte[] data = new byte[(int) readVarInt()];
-        return container.get().readBinary(data) > 0 ? new String(data) : "";
+        return container.get().readBinary(data) > 0 ? new String(data, StandardCharsets.UTF_8) : "";
     }
 
     public byte readByte() throws IOException {

--- a/src/main/java/com/github/housepower/jdbc/serializer/BinarySerializer.java
+++ b/src/main/java/com/github/housepower/jdbc/serializer/BinarySerializer.java
@@ -6,6 +6,7 @@ import com.github.housepower.jdbc.misc.Container;
 import com.github.housepower.jdbc.settings.ClickHouseDefines;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class BinarySerializer {
     private final Container<BuffedWriter> container;
@@ -69,7 +70,7 @@ public class BinarySerializer {
     }
 
     public void writeStringBinary(String binary) throws IOException {
-        byte []bs = binary.getBytes();
+        byte []bs = binary.getBytes(StandardCharsets.UTF_8);
         writeVarInt(bs.length);
         container.get().writeBinary(bs);
     }

--- a/src/main/java/com/github/housepower/jdbc/statement/AbstractPreparedStatement.java
+++ b/src/main/java/com/github/housepower/jdbc/statement/AbstractPreparedStatement.java
@@ -13,12 +13,13 @@ import java.sql.SQLException;
 import java.sql.Struct;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 public abstract class AbstractPreparedStatement extends ClickHouseStatement implements PreparedStatement {
 
     private final String[] queryParts;
-    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-    private final SimpleDateFormat timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+    private final SimpleDateFormat timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
 
     protected Object[] parameters;
 

--- a/src/test/java/com/github/housepower/jdbc/QueryComplexTypeITest.java
+++ b/src/test/java/com/github/housepower/jdbc/QueryComplexTypeITest.java
@@ -9,6 +9,7 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.text.SimpleDateFormat;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -16,7 +17,7 @@ public class QueryComplexTypeITest extends AbstractITest {
 
     @Test
     public void successfullyDate() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss", Locale.ROOT);
 
         // use client timezone, Asia/Shanghai in traivs-ci
         withNewConnection(connection -> {

--- a/src/test/java/com/github/housepower/jdbc/benchmark/ProfileBenchmark.java
+++ b/src/test/java/com/github/housepower/jdbc/benchmark/ProfileBenchmark.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.Locale;
 
 /**
  */
@@ -16,7 +17,7 @@ public class ProfileBenchmark extends AbstractIBenchmark{
 
     public WithConnection benchSelectSumInt = connection -> {
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery(String.format("SELECT number as n1 from numbers(%d)", n));
+        ResultSet rs = statement.executeQuery(String.format(Locale.ROOT, "SELECT number as n1 from numbers(%d)", n));
 
         long sum = 0;
         long counter = 0;
@@ -35,7 +36,7 @@ public class ProfileBenchmark extends AbstractIBenchmark{
 
     public WithConnection benchSelectSumDouble = connection -> {
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery(String.format("SELECT number/rand64() as n1 from numbers(%d)", n));
+        ResultSet rs = statement.executeQuery(String.format(Locale.ROOT, "SELECT number/rand64() as n1 from numbers(%d)", n));
 
         double sum = 0;
         long counter = 0;

--- a/src/test/java/com/github/housepower/jdbc/benchmark/Profiler.java
+++ b/src/test/java/com/github/housepower/jdbc/benchmark/Profiler.java
@@ -1,5 +1,7 @@
 package com.github.housepower.jdbc.benchmark;
 
+import java.util.Locale;
+
 /**
  * From https://gist.github.com/gothug/3b35fe0cec302efe6f8314a9cab8865e
  */
@@ -24,7 +26,7 @@ public class Profiler {
     }
 
     public static String fixedLengthString(String string, int length) {
-        return String.format("%1$"+length+ "s", string);
+        return String.format(Locale.ROOT, "%1$"+length+ "s", string);
     }
 
 

--- a/src/test/java/com/github/housepower/jdbc/benchmark/SelectIBenchmark.java
+++ b/src/test/java/com/github/housepower/jdbc/benchmark/SelectIBenchmark.java
@@ -7,6 +7,7 @@ import org.openjdk.jmh.annotations.Param;
 
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.Locale;
 
 /**
  */
@@ -16,7 +17,7 @@ public class SelectIBenchmark extends AbstractIBenchmark {
     public WithConnection benchSelect = connection -> {
         long sum = 0;
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery(String.format("SELECT number as n1, 'i_am_a_string' , now(), today() from numbers(%d)", selectNumber));
+        ResultSet rs = statement.executeQuery(String.format(Locale.ROOT, "SELECT number as n1, 'i_am_a_string' , now(), today() from numbers(%d)", selectNumber));
         while (rs.next()) {
             sum += rs.getLong(1);
 


### PR DESCRIPTION
This PR fixes the code of this library, which has some shortcomings:
- uses default charset (breaks serializing Strings from wire protocol)
- uses possibly date formats with incorrect decimal symbols when executed in a locale which uses different decimal symbols (like Hindi/Korean languages)

The detection of problematic parts is done by forbiddenapis (https://github.com/policeman-tools/forbidden-apis), which was included as a new maven plugin. The POM file itsself also had some problems regarding charset encoding (source files were not interpreted as UTF-8); I fixed this, too.

The forbiddenapis plugin found basically those major issues:

1. Wire format encoding/decoding of strings relied on platform's default charset. As soon as you use the JDBC driver on Windows or on other platform that DO NOT default to UTF-8 this lead to platform dependent string encoding. Issue #107 mentions this already. @sundy-li mentioned that everything is de/encoded as UTF-8 which is definitely not true. The good thing with this patch is: Whenever you call `new String(byte[])` or `String#getBytes()` without this PR, it first reads the default charset from a synchronized (!!!!!) field and applies it to the byte array - this may cause slowdown. By explicitely specifiying `StandardCharsets.UTF_8` the serialization is done in the most efficient way and is also consistent with expectation and your documentation. To fully implement #107, one just have to change the few places to make the actually used charset configureable through JDBC URL parameters. This would be a followup issue.

2. Some parts use wrong Locale when craeting Dates/Times or formatting messages. If you serialize dates times in ISO format you have to create the date formatter using the ROOT locale, otherwise it uses the platform default. The platform default mostly works, but in many asian countries (e.g. Hindu stuff), the actual decimal symbols are not 0,1,2,3,4,5,6,7,8,9 but some strange symbols. The ROOT locale is also fastest when creating/reading STrings, as no mapping is needed. In addition some error messages were formatted using English texts, in that case the error message should contain the parameterized decimals in correct symbols.

Forbiddenapis also found that the code uses java.sql.Timestamp's deprecated (and heavily broken in some Locales) constructor in some tests, but I did not fix that yet. Forbiddenapis can detect usage of deprecated APIs easily. I can make a followup PR or fix the tests in this PR, if you like. Nevertheless, I don't really take care of tests, as production code is more important. If tests fail, people can fix their test runner setup to use english locales and UTF-8 as charset :-) I also excluded JMH-generated classes from checks.

It would be good to apply this ASAP and make a release, because otherwise we cant use the driver in a multi-language environment!