### PR TITLE
Statement inheritance refactoring

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/statement/AbstractPreparedStatement.java
+++ b/src/main/java/com/github/housepower/jdbc/statement/AbstractPreparedStatement.java
@@ -1,6 +1,5 @@
 package com.github.housepower.jdbc.statement;
 
-
 import com.github.housepower.jdbc.ClickHouseConnection;
 import com.github.housepower.jdbc.misc.Validate;
 
@@ -8,14 +7,13 @@ import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Date;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Struct;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
-public abstract class AbstractPreparedStatement extends ClickHouseStatement implements PreparedStatement {
+public abstract class AbstractPreparedStatement extends ClickHouseStatement {
 
     private final String[] queryParts;
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
@@ -85,7 +83,6 @@ public abstract class AbstractPreparedStatement extends ClickHouseStatement impl
         setObject(index, x);
     }
 
-
     @Override
     public void setTimestamp(int index, Timestamp x) throws SQLException {
         setObject(index, x);
@@ -114,12 +111,12 @@ public abstract class AbstractPreparedStatement extends ClickHouseStatement impl
     }
 
     protected String assembleQueryPartsAndParameters() throws SQLException {
-        //TODO: move to DataType
+        // TODO: move to DataType
         StringBuilder queryBuilder = new StringBuilder();
         for (int i = 0; i < queryParts.length; i++) {
             if (i - 1 >= 0 && i - 1 < parameters.length) {
                 Validate.isTrue(assembleParameter(parameters[i - 1], queryBuilder),
-                    "UNKNOWN DataType :" + (parameters[i - 1] == null ? null : parameters[i - 1].getClass()));
+                        "UNKNOWN DataType :" + (parameters[i - 1] == null ? null : parameters[i - 1].getClass()));
             }
             queryBuilder.append(queryParts[i]);
         }
@@ -127,7 +124,8 @@ public abstract class AbstractPreparedStatement extends ClickHouseStatement impl
     }
 
     private boolean assembleParameter(Object parameter, StringBuilder queryBuilder) throws SQLException {
-        return assembleSimpleParameter(queryBuilder, parameter) || assembleComplexQuotedParameter(queryBuilder, parameter);
+        return assembleSimpleParameter(queryBuilder, parameter)
+                || assembleComplexQuotedParameter(queryBuilder, parameter);
 
     }
 

--- a/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
+++ b/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
@@ -19,9 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ClickHouseStatement extends SQLStatement {
-    private static final Pattern
-        VALUES_REGEX =
-        Pattern.compile("[V|v][A|a][L|l][U|u][E|e][S|s]\\s*\\(");
+    private static final Pattern VALUES_REGEX = Pattern.compile("[V|v][A|a][L|l][U|u][E|e][S|s]\\s*\\(");
 
     private ResultSet lastResultSet;
     protected Block block;
@@ -29,7 +27,6 @@ public class ClickHouseStatement extends SQLStatement {
 
     private long maxRows;
     private ClickHouseConfig cfg;
-
 
     public ClickHouseStatement(ClickHouseConnection connection) {
         this.connection = connection;
@@ -160,7 +157,6 @@ public class ClickHouseStatement extends SQLStatement {
         return 0;
     }
 
-
     @Override
     public int getFetchSize() throws SQLException {
         return 0;
@@ -252,7 +248,6 @@ public class ClickHouseStatement extends SQLStatement {
         }
         throw new SQLException("Cannot unwrap to " + iface.getName());
     }
-
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {

--- a/src/main/java/com/github/housepower/jdbc/wrapper/SQLStatement.java
+++ b/src/main/java/com/github/housepower/jdbc/wrapper/SQLStatement.java
@@ -7,7 +7,7 @@ import java.net.URL;
 import java.sql.*;
 import java.util.Calendar;
 
-public abstract class SQLStatement implements Statement, PreparedStatement {
+public abstract class SQLStatement implements PreparedStatement {
 
     @Override
     public ResultSet executeQuery(String sql) throws SQLException {
@@ -228,7 +228,6 @@ public abstract class SQLStatement implements Statement, PreparedStatement {
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
-
 
     @Override
     public ResultSet executeQuery() throws SQLException {
@@ -451,8 +450,7 @@ public abstract class SQLStatement implements Statement, PreparedStatement {
     }
 
     @Override
-    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
-        throws SQLException {
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 


### PR DESCRIPTION
Remove duplicate interface inheritance as in the following class definition
`public abstract class AbstractPreparedStatement extends ClickHouseStatement implements PreparedStatement `

In the code above: `ClickHouseStatement` extends from `SQLStatement` while `SQLStatement` is already extended from `PreparedStatement`

So `AbstractPreparedStatement` don't need to say that it gonna implements PreparedStatement  