### PR TITLE
Enhance & Fix parse host name in jdbc connection string

### DIFF
--- a/src/main/java/com/github/housepower/jdbc/settings/ClickHouseConfig.java
+++ b/src/main/java/com/github/housepower/jdbc/settings/ClickHouseConfig.java
@@ -31,7 +31,7 @@ public class ClickHouseConfig {
     private Map<SettingKey, Object> settings;
 
     public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
-    public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^/:\s]+)(:(?<port>\\d+))?");
+    public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^/:\\s]+)(:(?<port>\\d+))?");
 
     private ClickHouseConfig() {
     }

--- a/src/main/java/com/github/housepower/jdbc/settings/ClickHouseConfig.java
+++ b/src/main/java/com/github/housepower/jdbc/settings/ClickHouseConfig.java
@@ -31,7 +31,7 @@ public class ClickHouseConfig {
     private Map<SettingKey, Object> settings;
 
     public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
-    public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^:\s]+)(:(?<port>\\d+))?");
+    public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^/:\s]+)(:(?<port>\\d+))?");
 
     private ClickHouseConfig() {
     }
@@ -103,37 +103,63 @@ public class ClickHouseConfig {
 
     private Map<SettingKey, Object> parseJDBCUrl(String jdbcUrl) throws SQLException {
         try {
-            String uriStr = jdbcUrl.substring(5);
-            URI uri = new URI(uriStr);
-            Map<SettingKey, Object> settings = new HashMap<SettingKey, Object>();
+            URI uri = new URI(jdbcUrl.substring(5));
 
-            String host = uri.getHost();
-            int port = uri.getPort();
-            String database = uri.getPath();
-            if (database != null && !database.isEmpty()) {
-                Matcher m = DB_PATH_PATTERN.matcher(database);
-                if (m.matches()) {
-                    settings.put(SettingKey.database, m.group(1));
-                } else {
-                    throw new URISyntaxException("wrong database name path: '" + database + "'", jdbcUrl);
-                }
-            }
-            if (host == null || host.isEmpty()) {
-                Matcher m = HOST_PORT_PATH_PATTERN.matcher(uriStr);
-                if (m.find()) {
-                    host = m.group("host");
-                } else {
-                    throw new URISyntaxException("no valid host was found", jdbcUrl);
-                }
-            }
-            settings.put(SettingKey.port, port);
+            String host = parseHost(jdbcUrl);
+            Integer port = parsePort(jdbcUrl);
+            String database = parseDatabase(jdbcUrl);
+            Map<SettingKey, Object> settings = new HashMap<SettingKey, Object>();
             settings.put(SettingKey.address, host);
+            settings.put(SettingKey.port, port);
+            settings.put(SettingKey.database, database);
             settings.putAll(extractQueryParameters(uri.getQuery()));
 
             return settings;
         } catch (URISyntaxException ex) {
             throw new SQLException(ex.getMessage(), ex);
         }
+    }
+
+    private String parseDatabase(String jdbcUrl) throws URISyntaxException {
+        URI uri = new URI(jdbcUrl.substring(5));
+        String database = uri.getPath();
+        if (database != null && !database.isEmpty()) {
+            Matcher m = DB_PATH_PATTERN.matcher(database);
+            if (m.matches()) {
+                database = m.group(1);
+            } else {
+                throw new URISyntaxException("wrong database name path: '" + database + "'", jdbcUrl);
+            }
+        }
+        return database;
+    }
+
+    private String parseHost(String jdbcUrl) throws URISyntaxException {
+        String uriStr = jdbcUrl.substring(5);
+        URI uri = new URI(uriStr);
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            Matcher m = HOST_PORT_PATH_PATTERN.matcher(uriStr);
+            if (m.find()) {
+                host = m.group("host");
+            } else {
+                throw new URISyntaxException("No valid host was found", jdbcUrl);
+            }
+        }
+        return host;
+    }
+
+    private Integer parsePort(String jdbcUrl) throws URISyntaxException {
+        String uriStr = jdbcUrl.substring(5);
+        URI uri = new URI(uriStr);
+        int port = uri.getPort();
+        if (port <= -1) {
+            Matcher m = HOST_PORT_PATH_PATTERN.matcher(uriStr);
+            if (m.find() && m.group("port") != null) {
+                port = Integer.parseInt(m.group("port"));
+            }
+        }
+        return port;
     }
 
     private Map<SettingKey, Object> extractQueryParameters(String queryParameters) throws SQLException {

--- a/src/main/java/com/github/housepower/jdbc/settings/ClickHouseConfig.java
+++ b/src/main/java/com/github/housepower/jdbc/settings/ClickHouseConfig.java
@@ -31,6 +31,7 @@ public class ClickHouseConfig {
     private Map<SettingKey, Object> settings;
 
     public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
+    public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^:\s]+)(:(?<port>\\d+))?");
 
     private ClickHouseConfig() {
     }
@@ -40,13 +41,15 @@ public class ClickHouseConfig {
         this.settings.putAll(parseJDBCProperties(properties));
 
         Object obj;
-        this.port = (obj = settings.remove(SettingKey.port)) == null ? 9000 : ((Integer) obj) == -1 ? 9000 : (Integer) obj;
+        this.port = (obj = settings.remove(SettingKey.port)) == null ? 9000
+                : ((Integer) obj) == -1 ? 9000 : (Integer) obj;
         this.address = (obj = settings.remove(SettingKey.address)) == null ? "127.0.0.1" : String.valueOf(obj);
         this.password = (obj = settings.remove(SettingKey.password)) == null ? "" : String.valueOf(obj);
         this.username = (obj = settings.remove(SettingKey.user)) == null ? "default" : String.valueOf(obj);
         this.database = (obj = settings.remove(SettingKey.database)) == null ? "default" : String.valueOf(obj);
 
-        // Java use time unit mills @ https://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#connect(java.net.SocketAddress,%20int)
+        // Java use time unit mills @
+        // https://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#connect(java.net.SocketAddress,%20int)
         this.soTimeout = (obj = settings.remove(SettingKey.query_timeout)) == null ? 0 : (Integer) obj * 1000;
         this.connectTimeout = (obj = settings.remove(SettingKey.connect_timeout)) == null ? 0 : (Integer) obj * 1000;
     }
@@ -100,9 +103,12 @@ public class ClickHouseConfig {
 
     private Map<SettingKey, Object> parseJDBCUrl(String jdbcUrl) throws SQLException {
         try {
-            URI uri = new URI(jdbcUrl.substring(5));
+            String uriStr = jdbcUrl.substring(5);
+            URI uri = new URI(uriStr);
             Map<SettingKey, Object> settings = new HashMap<SettingKey, Object>();
 
+            String host = uri.getHost();
+            int port = uri.getPort();
             String database = uri.getPath();
             if (database != null && !database.isEmpty()) {
                 Matcher m = DB_PATH_PATTERN.matcher(database);
@@ -112,9 +118,16 @@ public class ClickHouseConfig {
                     throw new URISyntaxException("wrong database name path: '" + database + "'", jdbcUrl);
                 }
             }
-
-            settings.put(SettingKey.port, uri.getPort());
-            settings.put(SettingKey.address, uri.getHost());
+            if (host == null || host.isEmpty()) {
+                Matcher m = HOST_PORT_PATH_PATTERN.matcher(uriStr);
+                if (m.find()) {
+                    host = m.group("host");
+                } else {
+                    throw new URISyntaxException("no valid host was found", jdbcUrl);
+                }
+            }
+            settings.put(SettingKey.port, port);
+            settings.put(SettingKey.address, host);
             settings.putAll(extractQueryParameters(uri.getQuery()));
 
             return settings;
@@ -130,7 +143,7 @@ public class ClickHouseConfig {
         while (tokenizer.hasMoreTokens()) {
             String[] queryParameter = tokenizer.nextToken().split("=", 2);
             Validate.isTrue(queryParameter.length == 2,
-                "ClickHouse JDBC URL Parameter '" + queryParameters + "' Error, Expected '='.");
+                    "ClickHouse JDBC URL Parameter '" + queryParameters + "' Error, Expected '='.");
 
             for (SettingKey settingKey : SettingKey.values()) {
                 if (settingKey.name().equalsIgnoreCase(queryParameter[0])) {
@@ -141,7 +154,7 @@ public class ClickHouseConfig {
         return parameters;
     }
 
-    public void setQueryTimeout(int timeout){
+    public void setQueryTimeout(int timeout) {
         this.soTimeout = timeout;
     }
 

--- a/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
+++ b/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
@@ -29,7 +29,8 @@ public class ConnectionParamITest {
 
     @Test(expected = SQLException.class)
     public void successfullyMaxRowsToRead() throws Exception {
-        Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1?max_rows_to_read=1&connect_timeout=10");
+        Connection connection = DriverManager
+                .getConnection("jdbc:clickhouse://127.0.0.1?max_rows_to_read=1&connect_timeout=10");
         Statement statement = connection.createStatement();
         ResultSet rs = statement.executeQuery("SELECT arrayJoin([1,2,3,4]) from numbers(100)");
         int rowsRead = 0;
@@ -41,7 +42,8 @@ public class ConnectionParamITest {
 
     @Test
     public void successfullyMaxResultRows() throws Exception {
-        Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1?max_result_rows=1&connect_timeout=10");
+        Connection connection = DriverManager
+                .getConnection("jdbc:clickhouse://127.0.0.1?max_result_rows=1&connect_timeout=10");
         Statement statement = connection.createStatement();
         statement.setMaxRows(400);
         ResultSet rs = statement.executeQuery("SELECT arrayJoin([1,2,3,4]) from numbers(100)");
@@ -55,10 +57,43 @@ public class ConnectionParamITest {
     @Test
     public void successfullyUrlParser() throws Exception {
         String url = "jdbc:clickhouse://127.0.0.1/system?min_insert_block_size_rows=1000&connect_timeout=50";
-        ClickHouseConfig config = new ClickHouseConfig(url , new Properties());
+        ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
         Assert.assertEquals(config.database(), "system");
         Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
 
+        Assert.assertEquals(config.connectTimeout(), 50000);
+    }
+
+    @Test
+    public void successfullyHostNameOnly() throws Exception {
+        String url = "jdbc:clickhouse://my_clickhouse_sever_host_name/system?min_insert_block_size_rows=1000&connect_timeout=50";
+        ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
+        Assert.assertEquals(config.address(), "my_clickhouse_sever_host_name");
+        Assert.assertEquals(config.port(), 9000);
+        Assert.assertEquals(config.database(), "system");
+        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
+        Assert.assertEquals(config.connectTimeout(), 50000);
+    }
+
+    @Test
+    public void successfullyHostNameWithDefaultPort() throws Exception {
+        String url = "jdbc:clickhouse://my_clickhouse_sever_host_name:9000/system?min_insert_block_size_rows=1000&connect_timeout=50";
+        ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
+        Assert.assertEquals(config.address(), "my_clickhouse_sever_host_name");
+        Assert.assertEquals(config.port(), 9000);
+        Assert.assertEquals(config.database(), "system");
+        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
+        Assert.assertEquals(config.connectTimeout(), 50000);
+    }
+
+    @Test
+    public void successfullyHostNameWithCustomPort() throws Exception {
+        String url = "jdbc:clickhouse://my_clickhouse_sever_host_name:1940/system?min_insert_block_size_rows=1000&connect_timeout=50";
+        ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
+        Assert.assertEquals(config.address(), "my_clickhouse_sever_host_name");
+        Assert.assertEquals(config.port(), 1940);
+        Assert.assertEquals(config.database(), "system");
+        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
         Assert.assertEquals(config.connectTimeout(), 50000);
     }
 }

--- a/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
+++ b/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
@@ -96,4 +96,5 @@ public class ConnectionParamITest {
         Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
         Assert.assertEquals(config.connectTimeout(), 50000);
     }
+
 }


### PR DESCRIPTION
Scenario:
- My ClickHouse server run in Docker with container name: `my_clickhouse_server` ( this is its hostname)
- I have another  microservice A ( run in the same network in Docker) connect to ClickHouse server using ClickHouse JDBC. 
- But i cannot connect to clickhouse using JDBC URL= "jdbc:clickhouse://my_clickhouse_server:9000/mydatabase". throw Connection refused exception.
--> Because this library required hostname must be 1 of 3 types: domain (domain.com, domain.net ... etc), IPv4 , IPv6.




