### PR TITLE
(#164) Migrate to `java.time` and code improve

### DIFF
--- a/Benchmark.md
+++ b/Benchmark.md
@@ -1,7 +1,7 @@
 ## benchmarks
 
 Benchmarks are run by the `github-workflow` docker integration-test, eg [here](https://pipelines.actions.githubusercontent.com/QbHe5hNOfFaRrXVIS27533x1xALCRW60s95Fnk3uNRnLoX4ScD/_apis/pipelines/1/runs/12/signedlogcontent/3?urlExpires=2020-08-02T12%3A52%3A27.0078520Z&urlSigningMethod=HMACV1&urlSignature=Zn3fh71kxFaHRNgjA8OZZVGUz0It45KTCe7DR8MeVtU%3D)
-- All benchmark codes could be seen in the [test code directory](https://github.com/housepower/Clickhouse-Native-JDBC/tree/master/src/test/java/com/github/housepower/jdbc/benchmark), you can do the bench on your machine too.
+- All benchmark codes could be seen in the [test code directory](./clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark), you can do the bench on your machine too.
 - Both  `Clickhouse-Native-JDBC` and `clickhouse-jdbc` are good jdbc clients. And `clickhouse-jdbc` are maintained better, 
     this benchmarks only show your some difference, users could choose freely according to their needs.
 - The result's score means the avg_time to process one operation, lower is better.

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseArray.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseArray.java
@@ -22,9 +22,7 @@ public class ClickHouseArray extends SQLArray {
 
     public ClickHouseArray slice(int offset, int length) {
         Object []result = new Object[length];
-        for (int i = 0 ; i < length; i ++) {
-            result[i] = data[i+offset];
-        }
+        if (length >= 0) System.arraycopy(data, offset, result, 0, length);
         return new ClickHouseArray(result);
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseStruct.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseStruct.java
@@ -9,7 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ClickHouseStruct extends SQLStruct {
-    private static final Pattern REGEX = Pattern.compile("\\_(\\d+)");
+    private static final Pattern REGEX = Pattern.compile("_(\\d+)");
 
     private final String type;
     private final Object[] attributes;

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/buffer/BuffedReader.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/buffer/BuffedReader.java
@@ -3,6 +3,7 @@ package com.github.housepower.jdbc.buffer;
 import java.io.IOException;
 
 public interface BuffedReader {
+
     int readBinary() throws IOException;
 
     int readBinary(byte[] bytes) throws IOException;

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/connect/PhysicalInfo.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/connect/PhysicalInfo.java
@@ -3,7 +3,7 @@ package com.github.housepower.jdbc.connect;
 import com.github.housepower.jdbc.protocol.QueryRequest.ClientInfo;
 import com.github.housepower.jdbc.settings.ClickHouseConfig;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 public class PhysicalInfo {
 
@@ -31,11 +31,11 @@ public class PhysicalInfo {
 
     public static class ServerInfo {
         private final long reversion;
-        private final TimeZone timeZone;
+        private final ZoneId timeZone;
         private final String displayName;
         private final ClickHouseConfig configure;
 
-        public ServerInfo(ClickHouseConfig configure, long reversion, TimeZone timeZone, String displayName) {
+        public ServerInfo(ClickHouseConfig configure, long reversion, ZoneId timeZone, String displayName) {
             this.configure = configure;
             this.reversion = reversion;
             this.timeZone = timeZone;
@@ -46,7 +46,7 @@ public class PhysicalInfo {
             return reversion;
         }
 
-        public TimeZone timeZone() {
+        public ZoneId timeZone() {
             return timeZone;
         }
 

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/Column.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/Column.java
@@ -72,7 +72,7 @@ public class Column {
         serializer.writeStringBinary(name);
         serializer.writeStringBinary(type.name());
 
-        //writer offsets
+        // writer offsets
         if (offsets != null) {
             for (List<Integer> offsetList : offsets) {
                 for (int offset : offsetList) {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/DataTypeFactory.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/DataTypeFactory.java
@@ -64,7 +64,7 @@ public class DataTypeFactory {
     }
 
     private static Map<String, IDataType> initialDataTypes() {
-        Map<String, IDataType> creators = new HashMap<String, IDataType>();
+        Map<String, IDataType> creators = new HashMap<>();
         
         creators.put("IPv4", new DataTypeIPv4());
         creators.put("UUID", new DataTypeUUID());

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/IDataType.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/IDataType.java
@@ -8,7 +8,13 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
 
+/**
+ * It would be nice if we introduce a Generic Type, `IDataType<T>`, then we can avoid using `Object` and type cast.
+ * Unfortunately Java not support unsigned number, UInt8(u_byte) must be represented by Int16(short), which will
+ * break the Generic Type constriction and cause compile failed.
+ */
 public interface IDataType {
+
     String name();
 
     int sqlTypeId();
@@ -18,21 +24,25 @@ public interface IDataType {
     Class javaTypeClass();
 
     boolean nullable();
+
     int getPrecision();
+
     int getScale();
 
     Object deserializeTextQuoted(SQLLexer lexer) throws SQLException;
+
     Object deserializeBinary(BinaryDeserializer deserializer) throws SQLException, IOException;
 
     void serializeBinary(Object data, BinarySerializer serializer) throws SQLException, IOException;
+
     default void serializeBinaryBulk(Iterator<Object> data, BinarySerializer serializer) throws SQLException, IOException {
-        while(data.hasNext()) {
+        while (data.hasNext()) {
             serializeBinary(data.next(), serializer);
         }
     }
 
-    default void serializeBinaryBulk(Object []data, BinarySerializer serializer) throws SQLException, IOException {
-        for(Object d : data) {
+    default void serializeBinaryBulk(Object[] data, BinarySerializer serializer) throws SQLException, IOException {
+        for (Object d : data) {
             serializeBinary(d, serializer);
         }
     }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeDate.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeDate.java
@@ -19,7 +19,14 @@ import java.util.TimeZone;
 
 public class DataTypeDate implements IDataType {
 
+    public static IDataType createDateType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) {
+        return new DataTypeDate(serverInfo);
+    }
+
+    // Since `Date` is mutable, and `defaultValue()` will return ref instead of a copy for performance,
+    // we should ensure DON'T modify it anywhere.
     private static final Date DEFAULT_VALUE = new Date(0);
+
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
 
     public DataTypeDate(PhysicalInfo.ServerInfo serverInfo) {
@@ -69,8 +76,7 @@ public class DataTypeDate implements IDataType {
     }
 
     @Override
-    public void serializeBinary(Object data, BinarySerializer serializer)
-        throws SQLException, IOException {
+    public void serializeBinary(Object data, BinarySerializer serializer) throws SQLException, IOException {
         long mills = ((Date) data).getTime();
         long daysSinceEpoch = mills / 1000 / 3600 / 24;
         serializer.writeShort((short) daysSinceEpoch);
@@ -110,9 +116,5 @@ public class DataTypeDate implements IDataType {
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static IDataType createDateType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) {
-        return new DataTypeDate(serverInfo);
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeDate.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeDate.java
@@ -2,20 +2,18 @@ package com.github.housepower.jdbc.data.type;
 
 import com.github.housepower.jdbc.connect.PhysicalInfo;
 import com.github.housepower.jdbc.data.IDataType;
+import com.github.housepower.jdbc.misc.DateTimeHelper;
 import com.github.housepower.jdbc.misc.SQLLexer;
 import com.github.housepower.jdbc.misc.Validate;
 import com.github.housepower.jdbc.serializer.BinaryDeserializer;
 import com.github.housepower.jdbc.serializer.BinarySerializer;
-import com.github.housepower.jdbc.settings.SettingKey;
 
 import java.io.IOException;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class DataTypeDate implements IDataType {
 
@@ -27,17 +25,10 @@ public class DataTypeDate implements IDataType {
     // we should ensure DON'T modify it anywhere.
     private static final Date DEFAULT_VALUE = new Date(0);
 
-    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+    private final ZoneId tz;
 
     public DataTypeDate(PhysicalInfo.ServerInfo serverInfo) {
-        TimeZone dateTimeZone;
-        if (!java.lang.Boolean.TRUE
-                 .equals(serverInfo.getConfigure().settings().get(SettingKey.use_client_time_zone))) {
-            dateTimeZone = serverInfo.timeZone();
-        } else {
-            dateTimeZone = TimeZone.getDefault();
-        }
-        this.dateFormat.setTimeZone(dateTimeZone);
+        this.tz = DateTimeHelper.chooseTimeZone(serverInfo);
     }
 
     @Override
@@ -89,8 +80,7 @@ public class DataTypeDate implements IDataType {
     }
 
     @Override
-    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer)
-        throws IOException {
+    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer) throws IOException {
         Date[] data = new Date[rows];
         for (int row = 0; row < rows; row++) {
             short daysSinceEpoch = deserializer.readShort();
@@ -109,12 +99,7 @@ public class DataTypeDate implements IDataType {
         int day = lexer.numberLiteral().intValue();
         Validate.isTrue(lexer.character() == '\'');
 
-        String timeStr = String.format(Locale.ROOT, "%04d-%02d-%02d", year, month, day);
-        try {
-            java.util.Date date = dateFormat.parse(timeStr);
-            return new Date(date.getTime());
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
+        ZonedDateTime zdt = ZonedDateTime.of(year, month, day, 0, 0, 0, 0, tz);
+        return new Date(zdt.toInstant().toEpochMilli());
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeFloat32.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeFloat32.java
@@ -71,5 +71,4 @@ public class DataTypeFloat32 implements IDataType {
     public Object deserializeTextQuoted(SQLLexer lexer) throws SQLException {
         return lexer.numberLiteral().floatValue();
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeFloat64.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeFloat64.java
@@ -71,5 +71,4 @@ public class DataTypeFloat64 implements IDataType {
     public Object deserializeTextQuoted(SQLLexer lexer) throws SQLException {
         return lexer.numberLiteral().doubleValue();
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeIPv4.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeIPv4.java
@@ -12,7 +12,7 @@ import java.sql.Types;
 public class DataTypeIPv4 implements IDataType {
 
     private static final Integer DEFAULT_VALUE = 0;
-    private boolean isUnsigned = true;
+    private final boolean isUnsigned = true;
 
     @Override
     public String name() {
@@ -50,8 +50,7 @@ public class DataTypeIPv4 implements IDataType {
     }
 
     @Override
-    public void serializeBinary(Object data, BinarySerializer serializer)
-        throws SQLException, IOException {
+    public void serializeBinary(Object data, BinarySerializer serializer) throws SQLException, IOException {
         serializer.writeInt(((Long) data).intValue());
     }
 
@@ -66,8 +65,7 @@ public class DataTypeIPv4 implements IDataType {
     }
 
     @Override
-    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer)
-        throws SQLException, IOException {
+    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer) throws SQLException, IOException {
         Object[] data = new Object[rows];
         for (int row = 0; row < rows; row++) {
             data[row] = this.deserializeBinary(deserializer);
@@ -79,5 +77,4 @@ public class DataTypeIPv4 implements IDataType {
     public Object deserializeTextQuoted(SQLLexer lexer) throws SQLException {
         return lexer.numberLiteral().longValue() & 0xffffffff;
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt16.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt16.java
@@ -13,7 +13,7 @@ public class DataTypeInt16 implements IDataType {
 
     private static final Short DEFAULT_VALUE = 0;
     private final String name;
-    private boolean isUnsigned;
+    private final boolean isUnsigned;
 
     public DataTypeInt16(String name) {
         this.name = name;
@@ -82,5 +82,4 @@ public class DataTypeInt16 implements IDataType {
     public Object deserializeTextQuoted(SQLLexer lexer) throws SQLException {
         return lexer.numberLiteral().shortValue();
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt32.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt32.java
@@ -13,7 +13,7 @@ public class DataTypeInt32 implements IDataType {
 
     private static final Integer DEFAULT_VALUE = 0;
     private final String name;
-    private boolean isUnsigned;
+    private final boolean isUnsigned;
 
     public DataTypeInt32(String name) {
         this.name = name;
@@ -56,14 +56,12 @@ public class DataTypeInt32 implements IDataType {
     }
 
     @Override
-    public void serializeBinary(Object data, BinarySerializer serializer)
-        throws SQLException, IOException {
+    public void serializeBinary(Object data, BinarySerializer serializer) throws SQLException, IOException {
         serializer.writeInt(((Number) data).intValue());
     }
 
     @Override
-    public Object deserializeBinary(BinaryDeserializer deserializer)
-        throws SQLException, IOException {
+    public Object deserializeBinary(BinaryDeserializer deserializer) throws SQLException, IOException {
         int res = deserializer.readInt();
         if (isUnsigned) {
             return 0xffffffffL & res;
@@ -85,5 +83,4 @@ public class DataTypeInt32 implements IDataType {
     public Object deserializeTextQuoted(SQLLexer lexer) throws SQLException {
         return lexer.numberLiteral().longValue() & 0xffffffff;
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt64.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt64.java
@@ -15,7 +15,7 @@ public class DataTypeInt64 implements IDataType {
 
     private static final Long DEFAULT_VALUE = 0L;
     private final String name;
-    private boolean isUnsigned;
+    private final boolean isUnsigned;
 
     private static final BigInteger TWO_COMPL_REF = BigInteger.ONE.shiftLeft(64);
 
@@ -70,19 +70,18 @@ public class DataTypeInt64 implements IDataType {
         throws SQLException, IOException {
         long l = deserializer.readLong();
         if (isUnsigned) {
-            BigInteger unsigned = new BigInteger(1, longToBytes(l));
-            return unsigned;
+            return new BigInteger(1, longToBytes(l));
         }
         return l;
     }
 
-    private static byte[] longToBytes(long x) {
+    private byte[] longToBytes(long x) {
         ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
         buffer.putLong(x);
         return buffer.array();
     }
 
-    public static BigInteger parseBigIntegerPositive(String num, int bitlen) {
+    public BigInteger parseBigIntegerPositive(String num, int bitlen) {
         BigInteger b = new BigInteger(num);
         if (b.compareTo(BigInteger.ZERO) < 0) {
             b = b.add(BigInteger.ONE.shiftLeft(bitlen));

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt8.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeInt8.java
@@ -13,7 +13,7 @@ public class DataTypeInt8 implements IDataType {
 
     private static final Byte DEFAULT_VALUE = 0;
     private final String name;
-    private boolean isUnsigned;
+    private final boolean isUnsigned;
 
     public DataTypeInt8(String name) {
         this.name = name;

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeString.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeString.java
@@ -57,8 +57,7 @@ public class DataTypeString implements IDataType {
     }
 
     @Override
-    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer)
-        throws SQLException, IOException {
+    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer) throws SQLException, IOException {
         String[] data = new String[rows];
         for (int row = 0; row < rows; row++) {
             data[row] = deserializer.readStringBinary();

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeUUID.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/DataTypeUUID.java
@@ -72,5 +72,4 @@ public class DataTypeUUID implements IDataType {
         }
         return data;
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime.java
@@ -21,6 +21,19 @@ import java.util.TimeZone;
 
 public class DataTypeDateTime implements IDataType {
 
+    public static IDataType createDateTimeType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
+        if (lexer.isCharacter('(')) {
+            Validate.isTrue(lexer.character() == '(');
+            StringView dataTimeZone = lexer.stringLiteral();
+            Validate.isTrue(lexer.character() == ')');
+            return new DataTypeDateTime("DateTime('" +
+                    dataTimeZone + "')", serverInfo);
+        }
+        return new DataTypeDateTime("DateTime", serverInfo);
+    }
+
+    // Since `Timestamp` is mutable, and `defaultValue()` will return ref instead of a copy for performance,
+    // we should ensure DON'T modify it anywhere.
     private static final Timestamp DEFAULT_VALUE = new Timestamp(0);
     private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
 
@@ -114,16 +127,5 @@ public class DataTypeDateTime implements IDataType {
             data[row] = new Timestamp(deserializer.readInt() * 1000L);
         }
         return data;
-    }
-
-    public static IDataType createDateTimeType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
-        if (lexer.isCharacter('(')) {
-            Validate.isTrue(lexer.character() == '(');
-            StringView dataTimeZone = lexer.stringLiteral();
-            Validate.isTrue(lexer.character() == ')');
-            return new DataTypeDateTime("DateTime('" +
-                                        dataTimeZone + "')", serverInfo);
-        }
-        return new DataTypeDateTime("DateTime", serverInfo);
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime.java
@@ -2,22 +2,19 @@ package com.github.housepower.jdbc.data.type.complex;
 
 import com.github.housepower.jdbc.connect.PhysicalInfo;
 import com.github.housepower.jdbc.data.IDataType;
+import com.github.housepower.jdbc.misc.DateTimeHelper;
 import com.github.housepower.jdbc.misc.SQLLexer;
 import com.github.housepower.jdbc.misc.StringView;
 import com.github.housepower.jdbc.misc.Validate;
 import com.github.housepower.jdbc.serializer.BinaryDeserializer;
 import com.github.housepower.jdbc.serializer.BinarySerializer;
-import com.github.housepower.jdbc.settings.SettingKey;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class DataTypeDateTime implements IDataType {
 
@@ -26,8 +23,7 @@ public class DataTypeDateTime implements IDataType {
             Validate.isTrue(lexer.character() == '(');
             StringView dataTimeZone = lexer.stringLiteral();
             Validate.isTrue(lexer.character() == ')');
-            return new DataTypeDateTime("DateTime('" +
-                    dataTimeZone + "')", serverInfo);
+            return new DataTypeDateTime("DateTime('" + dataTimeZone + "')", serverInfo);
         }
         return new DataTypeDateTime("DateTime", serverInfo);
     }
@@ -35,18 +31,13 @@ public class DataTypeDateTime implements IDataType {
     // Since `Timestamp` is mutable, and `defaultValue()` will return ref instead of a copy for performance,
     // we should ensure DON'T modify it anywhere.
     private static final Timestamp DEFAULT_VALUE = new Timestamp(0);
-    private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
+    private final ZoneId tz;
 
     private final String name;
 
     public DataTypeDateTime(String name, PhysicalInfo.ServerInfo serverInfo) {
         this.name = name;
-        if (!java.lang.Boolean.TRUE
-            .equals(serverInfo.getConfigure().settings().get(SettingKey.use_client_time_zone))) {
-            dateTimeFormat.setTimeZone(serverInfo.timeZone());
-        } else {
-            dateTimeFormat.setTimeZone(TimeZone.getDefault());
-        }
+        this.tz = DateTimeHelper.chooseTimeZone(serverInfo);
     }
 
     @Override
@@ -74,10 +65,10 @@ public class DataTypeDateTime implements IDataType {
         return false;
     }
 
-	@Override
-	public int getPrecision() {
-		return 0;
-	}
+    @Override
+    public int getPrecision() {
+        return 0;
+    }
 
     @Override
     public int getScale() {
@@ -100,14 +91,8 @@ public class DataTypeDateTime implements IDataType {
         int seconds = lexer.numberLiteral().intValue();
         Validate.isTrue(lexer.character() == '\'');
 
-        String timeStr = String.format(Locale.ROOT, "%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hours, minutes, seconds);
-
-        try {
-            Date date = dateTimeFormat.parse(timeStr);
-            return new Timestamp(date.getTime());
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
+        ZonedDateTime zdt = ZonedDateTime.of(year, month, day, hours, minutes, seconds, 0, tz);
+        return Timestamp.from(zdt.toInstant());
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
@@ -20,6 +20,26 @@ import java.util.TimeZone;
 
 public class DataTypeDateTime64 implements IDataType {
 
+    public static DataTypeDateTime64 createDateTime64Type(SQLLexer lexer, ServerInfo serverInfo) throws SQLException {
+        if (lexer.isCharacter('(')) {
+            Validate.isTrue(lexer.character() == '(');
+            int precision = lexer.numberLiteral().intValue();
+            if (lexer.isCharacter(',')) {
+                Validate.isTrue(lexer.character() == ',');
+                Validate.isTrue(lexer.isWhitespace());
+                StringView dataTimeZone = lexer.stringLiteral();
+                Validate.isTrue(lexer.character() == ')');
+                return new DataTypeDateTime64("DateTime64(" + precision + ", '" + dataTimeZone + "')", serverInfo);
+            }
+
+            Validate.isTrue(lexer.character() == ')');
+            return new DataTypeDateTime64("DateTime64(" + precision + ")", serverInfo);
+        }
+        return new DataTypeDateTime64("DateTime64", serverInfo);
+    }
+
+    // Since `Timestamp` is mutable, and `defaultValue()` will return ref instead of a copy for performance,
+    // we should ensure DON'T modify it anywhere.
     public static final Timestamp DEFAULT_VALUE = new Timestamp(0);
     public static final int NANOS_IN_SECOND = 1_000_000_000;
     public static final int MILLIS_IN_SECOND = 1000;
@@ -42,24 +62,6 @@ public class DataTypeDateTime64 implements IDataType {
             timeZone = TimeZone.getDefault();
         }
         return timeZone;
-    }
-
-    public static DataTypeDateTime64 createDateTime64Type(SQLLexer lexer, ServerInfo serverInfo) throws SQLException {
-        if (lexer.isCharacter('(')) {
-            Validate.isTrue(lexer.character() == '(');
-            int precision = lexer.numberLiteral().intValue();
-            if (lexer.isCharacter(',')) {
-                Validate.isTrue(lexer.character() == ',');
-                Validate.isTrue(lexer.isWhitespace());
-                StringView dataTimeZone = lexer.stringLiteral();
-                Validate.isTrue(lexer.character() == ')');
-                return new DataTypeDateTime64("DateTime64(" + precision + ", '" + dataTimeZone + "')", serverInfo);
-            }
-
-            Validate.isTrue(lexer.character() == ')');
-            return new DataTypeDateTime64("DateTime64(" + precision + ")", serverInfo);
-        }
-        return new DataTypeDateTime64("DateTime64", serverInfo);
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
@@ -41,7 +41,6 @@ public class DataTypeDateTime64 implements IDataType {
     public static final Timestamp DEFAULT_VALUE = new Timestamp(0);
     public static final int NANOS_IN_SECOND = 1_000_000_000;
     public static final int MILLIS_IN_SECOND = 1000;
-    //    private final DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS", Locale.ROOT);
     private final String name;
     private final ZoneId tz;
 

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDateTime64.java
@@ -2,21 +2,19 @@ package com.github.housepower.jdbc.data.type.complex;
 
 import com.github.housepower.jdbc.connect.PhysicalInfo.ServerInfo;
 import com.github.housepower.jdbc.data.IDataType;
+import com.github.housepower.jdbc.misc.DateTimeHelper;
 import com.github.housepower.jdbc.misc.SQLLexer;
 import com.github.housepower.jdbc.misc.StringView;
 import com.github.housepower.jdbc.misc.Validate;
 import com.github.housepower.jdbc.serializer.BinaryDeserializer;
 import com.github.housepower.jdbc.serializer.BinarySerializer;
-import com.github.housepower.jdbc.settings.SettingKey;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class DataTypeDateTime64 implements IDataType {
 
@@ -43,25 +41,13 @@ public class DataTypeDateTime64 implements IDataType {
     public static final Timestamp DEFAULT_VALUE = new Timestamp(0);
     public static final int NANOS_IN_SECOND = 1_000_000_000;
     public static final int MILLIS_IN_SECOND = 1000;
-    private final DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS", Locale.ROOT);
+    //    private final DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS", Locale.ROOT);
     private final String name;
-    private final TimeZone timeZone;
+    private final ZoneId tz;
 
     public DataTypeDateTime64(String name, ServerInfo serverInfo) {
-        TimeZone timeZone1 = chooseTimeZone(serverInfo);
         this.name = name;
-        this.timeZone = timeZone1;
-        this.dateTimeFormat.withZone(timeZone1.toZoneId());
-    }
-
-    private static TimeZone chooseTimeZone(ServerInfo serverInfo) {
-        TimeZone timeZone;
-        if (!Boolean.TRUE.equals(serverInfo.getConfigure().settings().get(SettingKey.use_client_time_zone))) {
-            timeZone = serverInfo.timeZone();
-        } else {
-            timeZone = TimeZone.getDefault();
-        }
-        return timeZone;
+        this.tz = DateTimeHelper.chooseTimeZone(serverInfo);
     }
 
     @Override
@@ -89,10 +75,10 @@ public class DataTypeDateTime64 implements IDataType {
         return false;
     }
 
-	@Override
-	public int getPrecision() {
-		return 0;
-	}
+    @Override
+    public int getPrecision() {
+        return 0;
+    }
 
     @Override
     public int getScale() {
@@ -121,9 +107,8 @@ public class DataTypeDateTime64 implements IDataType {
         Validate.isTrue(lexer.character() == '\'');
         Validate.isTrue(lexer.character() == ')');
 
-        String timeStr = String.format(Locale.ROOT, "%04d-%02d-%02d %02d:%02d:%02d.%09d", year, month, day, hours, minutes, seconds, nanos);
-        LocalDateTime dateTime = LocalDateTime.parse(timeStr, dateTimeFormat);
-        return Timestamp.valueOf(dateTime);
+        ZonedDateTime zdt = ZonedDateTime.of(year, month, day, hours, minutes, seconds, nanos, tz);
+        return Timestamp.from(zdt.toInstant());
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDecimal.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeDecimal.java
@@ -17,14 +17,20 @@ import java.util.Locale;
 
 public class DataTypeDecimal implements IDataType {
 
+    public static IDataType createDecimalType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
+        Validate.isTrue(lexer.character() == '(');
+        Number precision = lexer.numberLiteral();
+        Validate.isTrue(lexer.character() == ',');
+        Number scale = lexer.numberLiteral();
+        Validate.isTrue(lexer.character() == ')');
+        return new DataTypeDecimal("Decimal(" + precision.intValue() + "," + scale.intValue() + ")",
+                precision.intValue(), scale.intValue());
+    }
+
     private final String name;
-
     private final int precision;
-
     private final int scale;
-
     private final BigDecimal scaleFactor;
-
     private final int nobits;
 
     public DataTypeDecimal(String name, int precision, int scale) {
@@ -37,7 +43,8 @@ public class DataTypeDecimal implements IDataType {
         } else if (this.precision <= 18) {
             this.nobits = 64;
         } else {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Precision[%d] is out of boundary.", precision));
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                    "Precision[%d] is out of boundary.", precision));
         }
     }
 
@@ -66,10 +73,10 @@ public class DataTypeDecimal implements IDataType {
         return false;
     }
 
-	@Override
-	public int getPrecision() {
-		return precision;
-	}
+    @Override
+    public int getPrecision() {
+        return precision;
+    }
 
     @Override
     public int getScale() {
@@ -78,7 +85,7 @@ public class DataTypeDecimal implements IDataType {
 
     @Override
     public Object deserializeTextQuoted(SQLLexer lexer) throws SQLException {
-        BigDecimal result = null;
+        BigDecimal result;
         if (lexer.isCharacter('\'')) {
             StringView v = lexer.stringLiteral();
             result = new BigDecimal(v.toString());
@@ -103,7 +110,8 @@ public class DataTypeDecimal implements IDataType {
                 break;
             }
             default: {
-                throw new RuntimeException(String.format(Locale.ENGLISH, "Unknown precision[%d] & scale[%d]", precision, scale));
+                throw new RuntimeException(String.format(Locale.ENGLISH,
+                        "Unknown precision[%d] & scale[%d]", precision, scale));
             }
         }
     }
@@ -125,7 +133,8 @@ public class DataTypeDecimal implements IDataType {
                 break;
             }
             default: {
-                throw new RuntimeException(String.format(Locale.ENGLISH, "Unknown precision[%d] & scale[%d]", precision, scale));
+                throw new RuntimeException(String.format(Locale.ENGLISH,
+                        "Unknown precision[%d] & scale[%d]", precision, scale));
             }
         }
         value = value.setScale(scale, RoundingMode.HALF_UP);
@@ -139,14 +148,5 @@ public class DataTypeDecimal implements IDataType {
             data[row] = (BigDecimal) this.deserializeBinary(deserializer);
         }
         return data;
-    }
-
-    public static IDataType createDecimalType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
-        Validate.isTrue(lexer.character() == '(');
-        Number precision = lexer.numberLiteral();
-        Validate.isTrue(lexer.character() == ',');
-        Number scale = lexer.numberLiteral();
-        Validate.isTrue(lexer.character() == ')');
-        return new DataTypeDecimal("Decimal(" + precision.intValue() + "," + scale.intValue() + ")", precision.intValue(), scale.intValue());
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeFixedString.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeFixedString.java
@@ -14,6 +14,14 @@ import java.sql.Types;
 
 public class DataTypeFixedString implements IDataType {
 
+    public static IDataType createFixedStringType(SQLLexer lexer,
+                                                  PhysicalInfo.ServerInfo serverInfo) throws SQLException {
+        Validate.isTrue(lexer.character() == '(');
+        Number fixedStringN = lexer.numberLiteral();
+        Validate.isTrue(lexer.character() == ')');
+        return new DataTypeFixedString("FixedString(" + fixedStringN.intValue() + ")", fixedStringN.intValue());
+    }
+
     private final int n;
     private final String name;
     private final String defaultValue;
@@ -54,10 +62,10 @@ public class DataTypeFixedString implements IDataType {
         return false;
     }
 
-	@Override
-	public int getPrecision() {
-		return n;
-	}
+    @Override
+    public int getPrecision() {
+        return n;
+    }
 
     @Override
     public int getScale() {
@@ -71,12 +79,12 @@ public class DataTypeFixedString implements IDataType {
 
     @Override
     public void serializeBinary(Object data, BinarySerializer serializer)
-        throws SQLException, IOException {
+            throws SQLException, IOException {
         writeBytes(((String) data).getBytes(StandardCharsets.UTF_8), serializer);
     }
 
     private void writeBytes(byte[] bs, BinarySerializer serializer)
-        throws IOException, SQLException {
+            throws IOException, SQLException {
         byte[] res;
         if (bs.length > n) {
             throw new SQLException("The size of FixString column is too large, got " + bs.length);
@@ -91,28 +99,16 @@ public class DataTypeFixedString implements IDataType {
     }
 
     @Override
-    public Object deserializeBinary(BinaryDeserializer deserializer)
-        throws SQLException, IOException {
+    public Object deserializeBinary(BinaryDeserializer deserializer) throws SQLException, IOException {
         return new String(deserializer.readBytes(n), StandardCharsets.UTF_8);
     }
 
     @Override
-    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer)
-        throws SQLException, IOException {
+    public Object[] deserializeBinaryBulk(int rows, BinaryDeserializer deserializer) throws SQLException, IOException {
         String[] data = new String[rows];
         for (int row = 0; row < rows; row++) {
             data[row] = new String(deserializer.readBytes(n), StandardCharsets.UTF_8);
         }
         return data;
-    }
-
-    public static IDataType createFixedStringType(SQLLexer lexer,
-                                                  PhysicalInfo.ServerInfo serverInfo)
-        throws SQLException {
-        Validate.isTrue(lexer.character() == '(');
-        Number fixedStringN = lexer.numberLiteral();
-        Validate.isTrue(lexer.character() == ')');
-        return new DataTypeFixedString("FixedString(" + fixedStringN.intValue() + ")",
-                                       fixedStringN.intValue());
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeNullable.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeNullable.java
@@ -13,6 +13,15 @@ import java.sql.SQLException;
 import java.util.List;
 
 public class DataTypeNullable implements IDataType {
+
+    public static IDataType createNullableType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
+        Validate.isTrue(lexer.character() == '(');
+        IDataType nestedType = DataTypeFactory.get(lexer, serverInfo);
+        Validate.isTrue(lexer.character() == ')');
+        return new DataTypeNullable(
+                "Nullable(" + nestedType.name() + ")", nestedType, DataTypeFactory.get("UInt8", serverInfo));
+    }
+
     private static final Short IS_NULL = 1;
     private static final Short NON_NULL = 0;
 
@@ -110,13 +119,5 @@ public class DataTypeNullable implements IDataType {
             }
         }
         return data;
-    }
-
-    public static IDataType createNullableType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
-        Validate.isTrue(lexer.character() == '(');
-        IDataType nestedType = DataTypeFactory.get(lexer, serverInfo);
-        Validate.isTrue(lexer.character() == ')');
-        return new DataTypeNullable(
-            "Nullable(" + nestedType.name() + ")", nestedType, DataTypeFactory.get("UInt8", serverInfo));
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeTuple.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/data/type/complex/DataTypeTuple.java
@@ -18,6 +18,27 @@ import java.util.List;
 
 public class DataTypeTuple implements IDataType {
 
+    public static DataTypeTuple createTupleType(SQLLexer lexer,
+                                                PhysicalInfo.ServerInfo serverInfo) throws SQLException {
+        Validate.isTrue(lexer.character() == '(');
+        List<IDataType> nestedDataTypes = new ArrayList<>();
+
+        for (; ; ) {
+            nestedDataTypes.add(DataTypeFactory.get(lexer, serverInfo));
+            char delimiter = lexer.character();
+            Validate.isTrue(delimiter == ',' || delimiter == ')');
+            if (delimiter == ')') {
+                StringBuilder builder = new StringBuilder("Tuple(");
+                for (int i = 0; i < nestedDataTypes.size(); i++) {
+                    if (i > 0)
+                        builder.append(",");
+                    builder.append(nestedDataTypes.get(i).name());
+                }
+                return new DataTypeTuple(builder.append(")").toString(), nestedDataTypes.toArray(new IDataType[0]));
+            }
+        }
+    }
+
     private final String name;
     private final IDataType[] nestedTypes;
 
@@ -55,10 +76,10 @@ public class DataTypeTuple implements IDataType {
         return false;
     }
 
-	@Override
-	public int getPrecision() {
-		return 0;
-	}
+    @Override
+    public int getPrecision() {
+        return 0;
+    }
 
     @Override
     public int getScale() {
@@ -127,26 +148,5 @@ public class DataTypeTuple implements IDataType {
         }
         Validate.isTrue(lexer.character() == ')');
         return new ClickHouseStruct("Tuple", tupleData);
-    }
-
-    public static DataTypeTuple createTupleType(SQLLexer lexer, PhysicalInfo.ServerInfo serverInfo) throws SQLException {
-        Validate.isTrue(lexer.character() == '(');
-        List<IDataType> nestedDataTypes = new ArrayList<IDataType>();
-
-        for (; ; ) {
-            nestedDataTypes.add(DataTypeFactory.get(lexer, serverInfo));
-            char delimiter = lexer.character();
-            Validate.isTrue(delimiter == ',' || delimiter == ')');
-            if (delimiter == ')') {
-                StringBuilder builder = new StringBuilder("Tuple(");
-                for (int i = 0; i < nestedDataTypes.size(); i++) {
-                    if (i > 0)
-                        builder.append(",");
-                    builder.append(nestedDataTypes.get(i).name());
-                }
-                return new DataTypeTuple(builder.append(")").toString(),
-                    nestedDataTypes.toArray(new IDataType[nestedDataTypes.size()]));
-            }
-        }
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/ClickHouseCityHash.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/ClickHouseCityHash.java
@@ -34,12 +34,9 @@ package com.github.housepower.jdbc.misc;
 
 /**
  * @author tamtam180 - kirscheless at gmail.com
- * @see http://google-opensource.blogspot.jp/2011/04/introducing-cityhash.html
- * @see http://code.google.com/p/cityhash/
+ * @see <a href="http://google-opensource.blogspot.jp/2011/04/introducing-cityhash.html"/>
+ * @see <a href="http://code.google.com/p/cityhash"/>
  *
- */
-
-/**
  * NOTE: The code is modified to be compatible with CityHash128 used in ClickHouse
  */
 public class ClickHouseCityHash {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/DateTimeHelper.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/DateTimeHelper.java
@@ -1,0 +1,26 @@
+package com.github.housepower.jdbc.misc;
+
+import com.github.housepower.jdbc.connect.PhysicalInfo;
+import com.github.housepower.jdbc.settings.SettingKey;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+public class DateTimeHelper {
+
+    public static ZoneId chooseTimeZone(PhysicalInfo.ServerInfo serverInfo) {
+        return (boolean) serverInfo.getConfigure().settings().getOrDefault(SettingKey.use_client_time_zone, false)
+                ? ZoneId.systemDefault() : serverInfo.timeZone();
+    }
+
+    public static LocalDateTime convertTimeZone(LocalDateTime localDateTime, ZoneId from, ZoneId to) {
+        return localDateTime.atZone(from).withZoneSameInstant(to).toLocalDateTime();
+    }
+
+    public static long toEpochMilli(ZonedDateTime zdt) {
+        return zdt.toInstant().toEpochMilli();
+    }
+}

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/SQLLexer.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/SQLLexer.java
@@ -157,12 +157,9 @@ public class SQLLexer {
     }
 
     private void skipAnyWhitespace() {
-        for (; pos < data.length; pos++) {
-            if (!(data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\n' || data[pos] == '\r'
-                    || data[pos] == '\f')) {
+        for (; pos < data.length; pos++)
+            if (data[pos] != ' ' && data[pos] != '\t' && data[pos] != '\n' && data[pos] != '\r' && data[pos] != '\f')
                 return;
-            }
-        }
     }
 
     private StringView stringLiteralWithQuoted(char quoted) throws SQLException {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/Slice.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/Slice.java
@@ -110,12 +110,10 @@ public class Slice implements Iterable<Object>{
 
         @Override
         public void remove() {
-            return;
         }
 
         @Override
         public void forEachRemaining(Consumer<? super Object> action) {
-            return;
         }
     }
 

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/Validate.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/misc/Validate.java
@@ -8,7 +8,6 @@ public class Validate {
         isTrue(expression, null);
     }
 
-
     public static void isTrue(boolean expression, String message) throws SQLException {
         if (!expression) {
             throw new SQLException(message);

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/protocol/DataRequest.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/protocol/DataRequest.java
@@ -30,5 +30,4 @@ public class DataRequest extends RequestOrResponse {
         block.writeTo(serializer);
         serializer.maybeDisableCompressed();
     }
-
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/serializer/BinaryDeserializer.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/serializer/BinaryDeserializer.java
@@ -15,7 +15,7 @@ public class BinaryDeserializer {
 
     public BinaryDeserializer(Socket socket) throws IOException {
         SocketBuffedReader socketReader = new SocketBuffedReader(socket);
-        container = new Container<BuffedReader>(socketReader, new CompressedBuffedReader(socketReader));
+        container = new Container<>(socketReader, new CompressedBuffedReader(socketReader));
     }
 
     public long readVarInt() throws IOException {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/serializer/BinarySerializer.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/serializer/BinarySerializer.java
@@ -13,7 +13,7 @@ public class BinarySerializer {
     private final boolean enableCompress;
 
     public BinarySerializer(BuffedWriter writer, boolean enableCompress) {
-        this.enableCompress =enableCompress;
+        this.enableCompress = enableCompress;
         BuffedWriter compressBuffer = null;
         if (enableCompress) {
             compressBuffer = new CompressedBuffedWriter(ClickHouseDefines.SOCKET_BUFFER_SIZE, writer);
@@ -70,7 +70,7 @@ public class BinarySerializer {
     }
 
     public void writeStringBinary(String binary) throws IOException {
-        byte []bs = binary.getBytes(StandardCharsets.UTF_8);
+        byte[] bs = binary.getBytes(StandardCharsets.UTF_8);
         writeVarInt(bs.length);
         container.get().writeBinary(bs);
     }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/settings/ClickHouseDefines.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/settings/ClickHouseDefines.java
@@ -10,8 +10,8 @@ public class ClickHouseDefines {
     public static final Integer DBMS_MIN_REVISION_WITH_SERVER_TIMEZONE = 54058;
     public static final Integer DBMS_MIN_REVISION_WITH_SERVER_DISPLAY_NAME = 54372;
 
-    public static final int MAX_BLOCK_SIZE = 1048576 * 10;
-    public static int SOCKET_BUFFER_SIZE = 1048576;
+    public static final int MAX_BLOCK_SIZE = 1024 * 1024 * 10;
+    public static int SOCKET_BUFFER_SIZE = 1024 * 1024;
 
-    public static int COLUMN_BUFFER = 1048576;
+    public static int COLUMN_BUFFER = 1024 * 1024;
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/AbstractPreparedStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/AbstractPreparedStatement.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.Struct;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Matcher;
 
@@ -106,9 +107,7 @@ public abstract class AbstractPreparedStatement extends ClickHouseStatement {
 
     @Override
     public void clearParameters() throws SQLException {
-        for (int i = 0; i < parameters.length; i++) {
-            parameters[i] = null;
-        }
+        Arrays.fill(parameters, null);
     }
 
     protected String assembleQueryPartsAndParameters() throws SQLException {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedInsertStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedInsertStatement.java
@@ -122,7 +122,7 @@ public class ClickHousePreparedInsertStatement extends AbstractPreparedStatement
         sb.append(super.toString());
         sb.append(": ");
         try {
-            sb.append(insertQuery + " (");
+            sb.append(insertQuery).append(" (");
             for (int i = 0; i < block.columns(); i++) {
                 Object obj = block.getObject(i);
                 if (obj == null) {
@@ -130,7 +130,7 @@ public class ClickHousePreparedInsertStatement extends AbstractPreparedStatement
                 } else if (obj instanceof Number) {
                     sb.append(obj);
                 } else {
-                    sb.append("'" + obj + "'");
+                    sb.append("'").append(obj).append("'");
                 }
                 if (i < block.columns() - 1) {
                     sb.append(",");

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedQueryStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedQueryStatement.java
@@ -61,8 +61,8 @@ public class ClickHousePreparedQueryStatement extends AbstractPreparedStatement 
                 }
             }
         }
-        queryParts.add(query.substring(lastPos, query.length()));
-        return queryParts.toArray(new String[queryParts.size()]);
+        queryParts.add(query.substring(lastPos));
+        return queryParts.toArray(new String[0]);
     }
     
     public String toString(){

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
@@ -105,7 +105,7 @@ public class ClickHouseStatement extends SQLStatement {
         if (max < 0) {
             throw new SQLException(String.format(Locale.ROOT, "Illegal maxRows value: %d", max));
         }
-        maxRows = max * 1L;
+        maxRows = max;
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/AbstractITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/AbstractITest.java
@@ -7,13 +7,10 @@ import java.util.Enumeration;
 
 public abstract class AbstractITest {
 
-    private static final int
-        SERVER_PORT =
-        Integer.valueOf(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
+    private static final int SERVER_PORT = Integer.parseInt(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
 
-    protected void withNewConnection(WithConnection withConnection, Object... args)
-        throws Exception {
-        // deregisterDriver other jdbc drivers
+    protected void withNewConnection(WithConnection withConnection, Object... args) throws Exception {
+        // remove all registered jdbc drivers
         Enumeration<Driver> drivers = DriverManager.getDrivers();
         while (drivers.hasMoreElements()) {
             DriverManager.deregisterDriver(drivers.nextElement());
@@ -28,14 +25,12 @@ public abstract class AbstractITest {
                 connectionStr += "?use_client_time_zone=true";
             }
         }
-        Connection connection = DriverManager.getConnection(connectionStr);
-        try {
+        try (Connection connection = DriverManager.getConnection(connectionStr)) {
             withConnection.apply(connection);
-        } finally {
-            connection.close();
         }
     }
 
+    @FunctionalInterface
     interface WithConnection {
         void apply(Connection connection) throws Exception;
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/BatchInsertITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/BatchInsertITest.java
@@ -1,9 +1,7 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -12,11 +10,13 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.*;
+
 public class BatchInsertITest extends AbstractITest {
 
     void assertBatchInsertResult(int[] result, int expectedRowCount) {
-        Assert.assertEquals(result.length, expectedRowCount);
-        Assert.assertEquals(Arrays.stream(result).sum(), expectedRowCount);
+        assertEquals(expectedRowCount, result.length);
+        assertEquals(expectedRowCount, Arrays.stream(result).sum());
     }
 
     @Test
@@ -42,12 +42,12 @@ public class BatchInsertITest extends AbstractITest {
             boolean hasResult = false;
             for (int i = 0; i < Byte.MAX_VALUE && rs.next(); i++) {
                 hasResult = true;
-                Assert.assertEquals(rs.getByte(1), i);
-                Assert.assertEquals(rs.getByte(2), 1);
-                Assert.assertEquals(rs.getString(3), "Zhang San" + i);
-                Assert.assertEquals(rs.getString(4), "张三" + i);
+                assertEquals(i, rs.getByte(1));
+                assertEquals(1, rs.getByte(2));
+                assertEquals("Zhang San" + i, rs.getString(3));
+                assertEquals("张三" + i, rs.getString(4));
             }
-            Assert.assertTrue(hasResult);
+            assertTrue(hasResult);
         });
 
     }
@@ -112,22 +112,21 @@ public class BatchInsertITest extends AbstractITest {
                 String name2 = rs.getString(2);
 
                 if (i * 2 >= insertBatchSize) {
-                    Assert.assertEquals(name1, null);
-                    Assert.assertEquals(name1, null);
+                    assertNull(name1);
                 } else {
-                    Assert.assertEquals(name1, "String");
-                    Assert.assertTrue(name2.contains("String"));
-                    Assert.assertTrue(name2.length() == 10);
+                    assertEquals("String", name1);
+                    assertTrue(name2.contains("String"));
+                    assertEquals(10, name2.length());
                 }
                 i++;
             }
 
             rs = stmt.executeQuery(
                     "select countIf(isNull(name)), countIf(isNotNull(name)), countIf(isNotNull(name2))  from test;");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(insertBatchSize / 2, rs.getInt(1));
-            Assert.assertEquals(insertBatchSize / 2, rs.getInt(2));
-            Assert.assertEquals(insertBatchSize / 2, rs.getInt(3));
+            assertTrue(rs.next());
+            assertEquals(insertBatchSize / 2, rs.getInt(1));
+            assertEquals(insertBatchSize / 2, rs.getInt(2));
+            assertEquals(insertBatchSize / 2, rs.getInt(3));
 
             stmt.executeQuery("DROP TABLE IF EXISTS test");
         });
@@ -160,8 +159,8 @@ public class BatchInsertITest extends AbstractITest {
 
             ResultSet rs = statement.executeQuery("select * from test");
             while (rs.next()) {
-                Assert.assertArrayEquals((Object[]) rs.getArray(1).getArray(), array.toArray());
-                Assert.assertArrayEquals((Object[]) rs.getArray(2).getArray(), array2.toArray());
+                assertArrayEquals(array.toArray(), (Object[]) rs.getArray(1).getArray());
+                assertArrayEquals(array2.toArray(), (Object[]) rs.getArray(2).getArray());
             }
         });
 
@@ -188,9 +187,9 @@ public class BatchInsertITest extends AbstractITest {
             assertBatchInsertResult(preparedStatement.executeBatch(), 24);
 
             long selectTime = time;
-            ResultSet rs = statement.executeQuery("SELECT  * FROM test ORDER BY time ASC");
+            ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY time ASC");
             while (rs.next()) {
-                Assert.assertEquals(rs.getTimestamp(1).getTime(), selectTime * 1000);
+                assertEquals(selectTime * 1000, rs.getTimestamp(1).getTime());
                 selectTime += 3600;
             }
         });

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickhouseDriverRegisterTest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickhouseDriverRegisterTest.java
@@ -1,15 +1,16 @@
 package com.github.housepower.jdbc;
 
 import com.github.housepower.jdbc.tool.EmbeddedDriver;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.DriverManager;
 import java.util.Properties;
 
+import static org.junit.Assert.*;
+
 public class ClickhouseDriverRegisterTest {
 
-    private static final int SERVER_PORT = Integer.valueOf(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
+    private static final int SERVER_PORT = Integer.parseInt(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
 
     @Test
     public void successfullyCreateConnection() throws Exception {
@@ -19,7 +20,7 @@ public class ClickhouseDriverRegisterTest {
         String mockedUrl = EmbeddedDriver.EMBEDDED_DRIVER_PREFIX + "//127.0.0.1:" + SERVER_PORT;
 
         DriverManager.registerDriver(new EmbeddedDriver());
-        Assert.assertEquals(EmbeddedDriver.MOCKED_CONNECTION, DriverManager.getConnection(mockedUrl, properties));
+        assertEquals(EmbeddedDriver.MOCKED_CONNECTION, DriverManager.getConnection(mockedUrl, properties));
     }
 
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
@@ -3,7 +3,6 @@ package com.github.housepower.jdbc;
 import com.github.housepower.jdbc.settings.ClickHouseConfig;
 import com.github.housepower.jdbc.settings.SettingKey;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,6 +14,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Enumeration;
 import java.util.Properties;
+
+import static org.junit.Assert.*;
 
 public class ConnectionParamITest {
 
@@ -37,7 +38,7 @@ public class ConnectionParamITest {
         while (rs.next()) {
             ++rowsRead;
         }
-        Assert.assertEquals(1, rowsRead); // not reached
+        assertEquals(1, rowsRead); // not reached
     }
 
     @Test
@@ -51,50 +52,50 @@ public class ConnectionParamITest {
         while (rs.next()) {
             ++rowsRead;
         }
-        Assert.assertEquals(400, rowsRead);
+        assertEquals(400, rowsRead);
     }
 
     @Test
     public void successfullyUrlParser() throws Exception {
         String url = "jdbc:clickhouse://127.0.0.1/system?min_insert_block_size_rows=1000&connect_timeout=50";
         ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
-        Assert.assertEquals(config.database(), "system");
-        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
+        assertEquals("system", config.database());
+        assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
 
-        Assert.assertEquals(config.connectTimeout(), 50000);
+        assertEquals(50000, config.connectTimeout());
     }
 
     @Test
     public void successfullyHostNameOnly() throws Exception {
         String url = "jdbc:clickhouse://my_clickhouse_sever_host_name/system?min_insert_block_size_rows=1000&connect_timeout=50";
         ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
-        Assert.assertEquals(config.address(), "my_clickhouse_sever_host_name");
-        Assert.assertEquals(config.port(), 9000);
-        Assert.assertEquals(config.database(), "system");
-        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
-        Assert.assertEquals(config.connectTimeout(), 50000);
+        assertEquals("my_clickhouse_sever_host_name", config.address());
+        assertEquals(9000, config.port());
+        assertEquals("system", config.database());
+        assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
+        assertEquals(50000, config.connectTimeout());
     }
 
     @Test
     public void successfullyHostNameWithDefaultPort() throws Exception {
         String url = "jdbc:clickhouse://my_clickhouse_sever_host_name:9000/system?min_insert_block_size_rows=1000&connect_timeout=50";
         ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
-        Assert.assertEquals(config.address(), "my_clickhouse_sever_host_name");
-        Assert.assertEquals(config.port(), 9000);
-        Assert.assertEquals(config.database(), "system");
-        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
-        Assert.assertEquals(config.connectTimeout(), 50000);
+        assertEquals("my_clickhouse_sever_host_name", config.address());
+        assertEquals(9000, config.port());
+        assertEquals("system", config.database());
+        assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
+        assertEquals(50000, config.connectTimeout());
     }
 
     @Test
     public void successfullyHostNameWithCustomPort() throws Exception {
         String url = "jdbc:clickhouse://my_clickhouse_sever_host_name:1940/system?min_insert_block_size_rows=1000&connect_timeout=50";
         ClickHouseConfig config = new ClickHouseConfig(url, new Properties());
-        Assert.assertEquals(config.address(), "my_clickhouse_sever_host_name");
-        Assert.assertEquals(config.port(), 1940);
-        Assert.assertEquals(config.database(), "system");
-        Assert.assertEquals(config.settings().get(SettingKey.min_insert_block_size_rows), 1000L);
-        Assert.assertEquals(config.connectTimeout(), 50000);
+        assertEquals("my_clickhouse_sever_host_name", config.address());
+        assertEquals(1940, config.port());
+        assertEquals("system", config.database());
+        assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
+        assertEquals(50000, config.connectTimeout());
     }
 
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/DecimalTypeITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/DecimalTypeITest.java
@@ -1,9 +1,9 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.*;
 
 import static org.junit.Assert.assertEquals;
@@ -14,11 +14,14 @@ public class DecimalTypeITest extends AbstractITest {
     public void testDecimalType() throws Exception {
         withNewConnection(connection -> {
             BigDecimal value32 = BigDecimal.valueOf(1.32);
-            value32 = value32.setScale(2);
+            value32 = value32.setScale(2, RoundingMode.HALF_UP);
             BigDecimal value64 = BigDecimal.valueOf(12343143412341.21D);
-            value64 = value64.setScale(5);
+            value64 = value64.setScale(5, RoundingMode.HALF_UP);
 
-            BigDecimal[] valueArray = new BigDecimal[]{BigDecimal.valueOf(412341.21D).setScale(3), BigDecimal.valueOf(512341.25D).setScale(3)};
+            BigDecimal[] valueArray = new BigDecimal[]{
+                    BigDecimal.valueOf(412341.21D).setScale(3, RoundingMode.HALF_UP),
+                    BigDecimal.valueOf(512341.25D).setScale(3, RoundingMode.HALF_UP)
+            };
             Statement statement = connection.createStatement();
             statement.execute("DROP TABLE IF EXISTS decimal_test");
             statement.execute("CREATE TABLE IF NOT EXISTS decimal_test (value32 Decimal(7,2), value64 Decimal(15,5), value_array Array(Decimal(5,3))) Engine=Memory();");
@@ -41,7 +44,6 @@ public class DecimalTypeITest extends AbstractITest {
                 BigDecimal rsValue64 = rs.getBigDecimal(2);
                 assertEquals(value64, rsValue64);
                 ClickHouseArray rsValueArray = (ClickHouseArray) rs.getArray(3);
-                Object v = rsValueArray.getArray();
                 Object[] decimalArray = (Object[]) rsValueArray.getArray();
                 assertEquals(decimalArray.length, valueArray.length);
                 for (int i = 0; i < valueArray.length; i++) {

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/InsertComplexTypeITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/InsertComplexTypeITest.java
@@ -1,10 +1,11 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.*;
 import java.time.LocalDateTime;
+
+import static org.junit.Assert.*;
 
 public class InsertComplexTypeITest extends AbstractITest {
 
@@ -17,12 +18,12 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_Array Array(UInt8), test_Array2 Array(Array(String)))ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES ([1, 2, 3, 4], [ ['1', '2'] ])");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertArrayEquals((Object[]) rs.getArray(1).getArray(), new Short[]{1, 2, 3, 4});
+            assertTrue(rs.next());
+            assertArrayEquals(new Short[]{1, 2, 3, 4}, (Object[]) rs.getArray(1).getArray());
             Object[] objects = (Object[]) rs.getArray(2).getArray();
             ClickHouseArray array = (ClickHouseArray) objects[0];
-            Assert.assertArrayEquals((Object[]) array.getArray(), new Object[]{"1", "2"});
-            Assert.assertFalse(rs.next());
+            assertArrayEquals(new Object[]{"1", "2"}, (Object[]) array.getArray());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -41,10 +42,10 @@ public class InsertComplexTypeITest extends AbstractITest {
             stmt.executeUpdate();
 
             ResultSet rs = statement.executeQuery("SELECT str, COUNT(0) FROM test group by str");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "abc");
-            Assert.assertEquals(rs.getInt(2), 2);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals("abc", rs.getString(1));
+            assertEquals(2, rs.getInt(2));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -58,15 +59,15 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_nullable Nullable(UInt8))ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(Null)(1)(3)(Null)");
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_nullable");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), 1);
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), 3);
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), 0);
-            Assert.assertTrue(rs.wasNull());
-            Assert.assertEquals(rs.getByte(1), 0);
-            Assert.assertTrue(rs.wasNull());
+            assertTrue(rs.next());
+            assertEquals(1, rs.getByte(1));
+            assertTrue(rs.next());
+            assertEquals(3, rs.getByte(1));
+            assertTrue(rs.next());
+            assertEquals(0, rs.getByte(1));
+            assertTrue(rs.wasNull());
+            assertEquals(0, rs.getByte(1));
+            assertTrue(rs.wasNull());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -80,15 +81,17 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_datetime DateTime('UTC'), test_datetme2 DateTime('Asia/Shanghai') )ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES('2000-01-01 08:01:01', '2000-01-01 08:01:01')");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
 
-            Assert.assertEquals(rs.getTimestamp(1).getTime(),
-                    Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 8, 1, 1, 0)).getTime());
+            assertEquals(
+                    Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 8, 1, 1, 0)).getTime(),
+                    rs.getTimestamp(1).getTime());
 
-            Assert.assertEquals(rs.getTimestamp(2).getTime(),
-                    Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 8, 1, 1, 0)).getTime());
+            assertEquals(
+                    Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 8, 1, 1, 0)).getTime(),
+                    rs.getTimestamp(2).getTime());
 
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         }, true);
     }
@@ -102,11 +105,12 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_datetime DateTime64(9, 'UTC'))ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(toDateTime64('2000-01-01 00:01:01.123456789'))");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
 
-            Assert.assertEquals(Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 0, 1, 1, 123456789)),
+            assertEquals(
+                    Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 0, 1, 1, 123456789)),
                     rs.getTimestamp(1));
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         }, true);
     }
@@ -120,10 +124,11 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_datetime DateTime64(9, 'UTC'))ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(toDateTime64('1970-01-01 00:00:00.000000000'))");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0)),
+            assertTrue(rs.next());
+            assertEquals(
+                    Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0)),
                     rs.getTimestamp(1));
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         }, true);
     }
@@ -137,11 +142,12 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_datetime DateTime64(9, 'UTC'))ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(toDateTime64('2105-12-31 23:59:59.999999999'))");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
 
-            Assert.assertEquals(Timestamp.valueOf(LocalDateTime.of(2105, 12, 31, 23, 59, 59, 999999999)),
+            assertEquals(
+                    Timestamp.valueOf(LocalDateTime.of(2105, 12, 31, 23, 59, 59, 999999999)),
                     rs.getTimestamp(1));
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         }, true);
     }
@@ -155,9 +161,11 @@ public class InsertComplexTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_tuple Tuple(String, UInt8))ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(('test_string', 1))");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertArrayEquals(((Struct) rs.getObject(1)).getAttributes(), new Object[]{"test_string", (short) (1)});
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertArrayEquals(
+                    new Object[]{"test_string", (short) (1)},
+                    ((Struct) rs.getObject(1)).getAttributes());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/InsertSimpleTypeITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/InsertSimpleTypeITest.java
@@ -1,6 +1,5 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -10,6 +9,8 @@ import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
 
 public class InsertSimpleTypeITest extends AbstractITest {
 
@@ -24,11 +25,11 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("INSERT INTO test VALUES(" + 255 + "," + Byte.MIN_VALUE + ")");
 
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_uInt8");
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             int aa = rs.getInt(1);
-            Assert.assertEquals(aa, 255);
-            Assert.assertEquals(rs.getByte(2), Byte.MIN_VALUE);
-            Assert.assertFalse(rs.next());
+            assertEquals(255, aa);
+            assertEquals(Byte.MIN_VALUE, rs.getByte(2));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -42,10 +43,10 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_uInt16 UInt16, test_Int16 Int16)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(" + Short.MAX_VALUE + "," + Short.MIN_VALUE + ")");
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_uInt16");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getShort(1), Short.MAX_VALUE);
-            Assert.assertEquals(rs.getShort(2), Short.MIN_VALUE);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(Short.MAX_VALUE, rs.getShort(1));
+            assertEquals(Short.MIN_VALUE, rs.getShort(2));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -59,10 +60,10 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_uInt32 UInt32, test_Int32 Int32)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(" + Integer.MAX_VALUE + "," + Integer.MIN_VALUE + ")");
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_uInt32");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), Integer.MAX_VALUE);
-            Assert.assertEquals(rs.getInt(2), Integer.MIN_VALUE);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(Integer.MAX_VALUE, rs.getInt(1));
+            assertEquals(Integer.MIN_VALUE, rs.getInt(2));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -71,8 +72,8 @@ public class InsertSimpleTypeITest extends AbstractITest {
     public void successfullyIPv4DataType() throws Exception {
         withNewConnection(connection -> {
             Statement statement = connection.createStatement();
-            Long minIp = 0l;
-            Long maxIp = (1l << 32) - 1;
+            long minIp = 0L;
+            long maxIp = (1L << 32) - 1;
 
             statement.executeQuery("DROP TABLE IF EXISTS test");
             statement.executeQuery("CREATE TABLE test(min_ip IPv4,max_ip IPv4)ENGINE=Log");
@@ -84,10 +85,10 @@ public class InsertSimpleTypeITest extends AbstractITest {
             }
             pstmt.executeBatch();
             ResultSet rs = statement.executeQuery("SELECT min_ip,max_ip FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getLong(1), minIp.longValue());
-            Assert.assertEquals(rs.getLong(2), maxIp.longValue());
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(minIp, rs.getLong(1));
+            assertEquals(maxIp, rs.getLong(2));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -101,10 +102,10 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_uInt64 UInt64, test_Int64 Int64)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(" + Long.MAX_VALUE + "," + Long.MIN_VALUE + ")");
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_uInt64");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getLong(1), Long.MAX_VALUE);
-            Assert.assertEquals(rs.getLong(2), Long.MIN_VALUE);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(Long.MAX_VALUE, rs.getLong(1));
+            assertEquals(Long.MIN_VALUE, rs.getLong(2));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -118,9 +119,9 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test String)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES('test_string')");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "test_string");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals("test_string", rs.getString(1));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -134,13 +135,15 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test Date, test2 Date)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES('2000-01-01', '2000-01-31')");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getDate(1).getTime() / TimeUnit.DAYS.toMillis(1),
-                    LocalDate.of(2000, 1, 1).atStartOfDay(ZoneOffset.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toLocalDate().toEpochDay());
-            Assert.assertEquals(rs.getDate(2).getTime() / TimeUnit.DAYS.toMillis(1),
-                    LocalDate.of(2000, 1, 31).atStartOfDay(ZoneOffset.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toLocalDate().toEpochDay());
+            assertTrue(rs.next());
+            assertEquals(
+                    LocalDate.of(2000, 1, 1).atStartOfDay(ZoneOffset.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toLocalDate().toEpochDay(),
+                    rs.getDate(1).getTime() / TimeUnit.DAYS.toMillis(1));
+            assertEquals(
+                    LocalDate.of(2000, 1, 31).atStartOfDay(ZoneOffset.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toLocalDate().toEpochDay(),
+                    rs.getDate(2).getTime() / TimeUnit.DAYS.toMillis(1));
 
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         }, true);
     }
@@ -154,11 +157,11 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_float32 Float32)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(" + Float.MIN_VALUE + ")(" + Float.MAX_VALUE + ")");
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_float32");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getFloat(1), Float.MIN_VALUE, 0.000000000001);
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getFloat(1), Float.MAX_VALUE, 0.000000000001);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(Float.MIN_VALUE, rs.getFloat(1), 0.000000000001);
+            assertTrue(rs.next());
+            assertEquals(Float.MAX_VALUE, rs.getFloat(1), 0.000000000001);
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -173,11 +176,11 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test_float64 Float64)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES(" + Double.MIN_VALUE + ")(" + Double.MAX_VALUE + ")");
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY test_float64");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getDouble(1), Double.MIN_VALUE, 0.000000000001);
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getDouble(1), Double.MAX_VALUE, 0.000000000001);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(Double.MIN_VALUE, rs.getDouble(1), 0.000000000001);
+            assertTrue(rs.next());
+            assertEquals(Double.MAX_VALUE, rs.getDouble(1), 0.000000000001);
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -191,9 +194,9 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery("CREATE TABLE test(test UUID)ENGINE=Log");
             statement.executeQuery("INSERT INTO test VALUES('01234567-89ab-cdef-0123-456789abcdef')");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "01234567-89ab-cdef-0123-456789abcdef");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals("01234567-89ab-cdef-0123-456789abcdef", rs.getString(1));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -206,11 +209,11 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.execute("CREATE TABLE test(id Int32) ENGINE = Log");
             statement.execute("INSERT INTO test VALUES (1), (2)");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertTrue(rs.next());
+            assertEquals(2, rs.getInt(1));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -230,19 +233,19 @@ public class InsertSimpleTypeITest extends AbstractITest {
             statement.executeQuery(insertSQL);
 
             ResultSet rs = statement.executeQuery("SELECT * FROM test ORDER BY i8");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), -1);
-            Assert.assertEquals(rs.getShort(1), (1 << 8) - 1);
+            assertTrue(rs.next());
+            assertEquals(-1, rs.getByte(1));
+            assertEquals((1 << 8) - 1, rs.getShort(1));
 
-            Assert.assertEquals(rs.getShort(2), -1);
-            Assert.assertEquals(rs.getInt(2), (1 << 16) - 1);
+            assertEquals(-1, rs.getShort(2));
+            assertEquals((1 << 16) - 1, rs.getInt(2));
 
-            Assert.assertEquals(rs.getInt(3), -1);
-            Assert.assertEquals(rs.getLong(3), 4294967295L);
+            assertEquals(-1, rs.getInt(3));
+            assertEquals(4294967295L, rs.getLong(3));
 
-            Assert.assertEquals(rs.getLong(4), -9223372036854775808L);
-            Assert.assertEquals(rs.getBigDecimal(4), new BigDecimal("9223372036854775808"));
-            Assert.assertFalse(rs.next());
+            assertEquals(-9223372036854775808L, rs.getLong(4));
+            assertEquals(new BigDecimal("9223372036854775808"), rs.getBigDecimal(4));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/IssueReproduceITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/IssueReproduceITest.java
@@ -2,17 +2,18 @@ package com.github.housepower.jdbc;
 
 import com.google.common.base.Strings;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
+import static org.junit.Assert.*;
+
 /**
  *
  */
-public class IssueReproduceITest extends AbstractITest{
+public class IssueReproduceITest extends AbstractITest {
     @Test
     public void testIssue63() throws Exception {
         withNewConnection(connection -> {
@@ -20,19 +21,19 @@ public class IssueReproduceITest extends AbstractITest{
             Statement statement = connection.createStatement();
             statement.executeQuery("DROP TABLE IF EXISTS test");
             String params = Strings.repeat("?, ", columnNum);
-            String columnTypes = "";
+            StringBuilder columnTypes = new StringBuilder();
             for (int i = 0; i < columnNum; i++) {
                 if (i != 0) {
-                    columnTypes += ", ";
+                    columnTypes.append(", ");
                 }
-                columnTypes += "t_" +i + " String";
+                columnTypes.append("t_").append(i).append(" String");
             }
 
-            statement.executeQuery("CREATE TABLE test( "  + columnTypes +  ")ENGINE=Log");
+            statement.executeQuery("CREATE TABLE test( " + columnTypes + ")ENGINE=Log");
             PreparedStatement pstmt = connection.prepareStatement("INSERT INTO test values(" + params.substring(0, params.length() - 2) + ")");
 
             for (int i = 0; i < 100; ++i) {
-                for (int j = 0; j < columnNum; j ++) {
+                for (int j = 0; j < columnNum; j++) {
                     pstmt.setString(j + 1, "String" + j);
                 }
                 pstmt.addBatch();
@@ -40,8 +41,8 @@ public class IssueReproduceITest extends AbstractITest{
             pstmt.executeBatch();
 
             ResultSet rs = statement.executeQuery("SELECT count(1) FROM test limit 1");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 100);
+            assertTrue(rs.next());
+            assertEquals(100, rs.getInt(1));
             statement.executeQuery("DROP TABLE IF EXISTS test");
         }, true);
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/PreparedStatementITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/PreparedStatementITest.java
@@ -1,14 +1,15 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
 
 public class PreparedStatementITest extends AbstractITest {
 
@@ -20,10 +21,10 @@ public class PreparedStatementITest extends AbstractITest {
             preparedStatement.setByte(1, (byte) 1);
             preparedStatement.setByte(2, (byte) 2);
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), 1);
-            Assert.assertEquals(rs.getByte(2), 2);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(1, rs.getByte(1));
+            assertEquals(2, rs.getByte(2));
+            assertFalse(rs.next());
         });
     }
 
@@ -35,10 +36,10 @@ public class PreparedStatementITest extends AbstractITest {
             preparedStatement.setShort(1, (short) 1);
             preparedStatement.setShort(2, (short) 2);
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getShort(1), 1);
-            Assert.assertEquals(rs.getShort(2), 2);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(1, rs.getShort(1));
+            assertEquals(2, rs.getShort(2));
+            assertFalse(rs.next());
         });
     }
 
@@ -50,10 +51,10 @@ public class PreparedStatementITest extends AbstractITest {
             preparedStatement.setInt(1, 1);
             preparedStatement.setInt(2, 2);
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getInt(2), 2);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertEquals(2, rs.getInt(2));
+            assertFalse(rs.next());
         });
     }
 
@@ -65,10 +66,10 @@ public class PreparedStatementITest extends AbstractITest {
             preparedStatement.setLong(1, 1);
             preparedStatement.setLong(2, 2);
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getLong(1), 1);
-            Assert.assertEquals(rs.getLong(2), 2);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(1, rs.getLong(1));
+            assertEquals(2, rs.getLong(2));
+            assertFalse(rs.next());
         });
     }
 
@@ -80,10 +81,10 @@ public class PreparedStatementITest extends AbstractITest {
             preparedStatement.setString(1, "test1");
             preparedStatement.setString(2, "test2");
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "test1");
-            Assert.assertEquals(rs.getString(2), "test2");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals("test1", rs.getString(1));
+            assertEquals("test2", rs.getString(2));
+            assertFalse(rs.next());
         });
     }
 
@@ -95,12 +96,12 @@ public class PreparedStatementITest extends AbstractITest {
             preparedStatement.setString(1, null);
             preparedStatement.setString(2, "test2");
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), null);
-            Assert.assertTrue(rs.wasNull());
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "test2");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertNull(rs.getString(1));
+            assertTrue(rs.wasNull());
+            assertTrue(rs.next());
+            assertEquals("test2", rs.getString(1));
+            assertFalse(rs.next());
         });
     }
 
@@ -112,10 +113,10 @@ public class PreparedStatementITest extends AbstractITest {
             long now = System.currentTimeMillis();
             preparedStatement.setDate(1, new Date(now));
             ResultSet rs = preparedStatement.executeQuery();
-            Assert.assertTrue(rs.next());
-//                Assert.assertEquals(rs.getDate(1).getTime() / TimeUnit.DAYS.toMillis(1),
-//                    now / TimeUnit.DAYS.toMillis(1) - 1);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(now / TimeUnit.DAYS.toMillis(1),
+                    rs.getDate(1).getTime() / TimeUnit.DAYS.toMillis(1));
+            assertFalse(rs.next());
         }, true);
     }
 
@@ -128,15 +129,15 @@ public class PreparedStatementITest extends AbstractITest {
             statement.execute("CREATE TABLE test(id UInt8, day Date, time DateTime)ENGINE = Log");
 
             PreparedStatement preparedStatement =
-                connection.prepareStatement("INSERT INTO test VALUES(?, ?, ?)");
+                    connection.prepareStatement("INSERT INTO test VALUES(?, ?, ?)");
 
             // 2018-07-01 19:00:00  Asia/Shanghai
             long time = 1530374400 + 19 * 3600;
 
-            preparedStatement.setByte(1, (byte)1);
+            preparedStatement.setByte(1, (byte) 1);
             preparedStatement.setDate(2, new Date(time * 1000));
             preparedStatement.setTimestamp(3, new Timestamp(time * 1000));
-            Assert.assertEquals(preparedStatement.executeUpdate(), 1);
+            assertEquals(1, preparedStatement.executeUpdate());
         });
     }
 

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QueryComplexTypeITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QueryComplexTypeITest.java
@@ -1,6 +1,5 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.Array;
@@ -13,6 +12,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static org.junit.Assert.*;
+
 public class QueryComplexTypeITest extends AbstractITest {
 
     @Test
@@ -24,25 +25,24 @@ public class QueryComplexTypeITest extends AbstractITest {
             Statement statement = connection.createStatement();
             ResultSet rs =
                 statement.executeQuery("select toDate('2020-01-01') as dateValue");
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
 
             dateFormat.setTimeZone(TimeZone.getTimeZone("Asia/Shanghai"));
             java.util.Date date = dateFormat.parse("2020-01-01 08:00:00");
-            Assert.assertEquals(rs.getDate(1).getTime(), date.getTime());
-            Assert.assertFalse(rs.next());
+            assertEquals(date.getTime(), rs.getDate(1).getTime());
+            assertFalse(rs.next());
         }, true);
 
         // use server timezone, UTC
         withNewConnection(connection -> {
             Statement statement = connection.createStatement();
-            ResultSet rs =
-                statement.executeQuery("select toDate('2020-01-01') as dateValue");
-            Assert.assertTrue(rs.next());
+            ResultSet rs = statement.executeQuery("select toDate('2020-01-01') as dateValue");
+            assertTrue(rs.next());
 
             dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             java.util.Date date = dateFormat.parse("2020-01-01 00:00:00");
-            Assert.assertEquals(rs.getDate(1).getTime(), date.getTime());
-            Assert.assertFalse(rs.next());
+            assertEquals(date.getTime(), rs.getDate(1).getTime());
+            assertFalse(rs.next());
         }, false);
     }
 
@@ -53,9 +53,9 @@ public class QueryComplexTypeITest extends AbstractITest {
             long ts = 946659723 * 1000L;
             ResultSet rs =
                 statement.executeQuery("SELECT nullIf(toDateTime(946659723), toDateTime(0))");
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getTimestamp(1).getTime(), ts);
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals(ts, rs.getTimestamp(1).getTime());
+            assertFalse(rs.next());
         });
     }
 
@@ -68,9 +68,9 @@ public class QueryComplexTypeITest extends AbstractITest {
                 rs =
                 statement.executeQuery("SELECT toFixedString('abc',3),toFixedString('abc',4)");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "abc");
-            Assert.assertEquals(rs.getString(2), "abc\u0000");
+            assertTrue(rs.next());
+            assertEquals("abc", rs.getString(1));
+            assertEquals("abc\u0000", rs.getString(2));
         });
     }
 
@@ -81,11 +81,11 @@ public class QueryComplexTypeITest extends AbstractITest {
 
             ResultSet rs = statement.executeQuery("SELECT arrayJoin([NULL,1])");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), 0);
-            Assert.assertTrue(rs.wasNull());
-            Assert.assertTrue(rs.next());
-            Assert.assertNotNull(rs.getObject(1));
+            assertTrue(rs.next());
+            assertEquals(0, rs.getByte(1));
+            assertTrue(rs.wasNull());
+            assertTrue(rs.next());
+            assertNotNull(rs.getObject(1));
         });
     }
 
@@ -98,12 +98,12 @@ public class QueryComplexTypeITest extends AbstractITest {
                 rs =
                 statement.executeQuery("SELECT arrayJoin([NULL,toFixedString('abc',3)])");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), null);
-            Assert.assertTrue(rs.wasNull());
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "abc");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertNull(rs.getString(1));
+            assertTrue(rs.wasNull());
+            assertTrue(rs.next());
+            assertEquals("abc", rs.getString(1));
+            assertFalse(rs.next());
         });
     }
 
@@ -116,22 +116,22 @@ public class QueryComplexTypeITest extends AbstractITest {
             ResultSet rs = statement.executeQuery("SELECT [[1], [2], [3], [4,5,6]] from numbers(10)");
 
             for (int i = 0; i < 10; i ++) {
-                Assert.assertTrue(rs.next());
+                assertTrue(rs.next());
                 Array array1 = rs.getArray(1);
                 Object[] objects = (Object[]) array1.getArray();
-                Assert.assertEquals(objects.length, 4);
+                assertEquals(4, objects.length);
 
                 ClickHouseArray a1 = (ClickHouseArray)(objects[0]);
                 ClickHouseArray a2 = (ClickHouseArray)(objects[1]);
                 ClickHouseArray a3 = (ClickHouseArray)(objects[2]);
                 ClickHouseArray a4 = (ClickHouseArray)(objects[3]);
 
-                Assert.assertArrayEquals((Object[]) a1.getArray(), new Short[]{(short) 1});
-                Assert.assertArrayEquals((Object[]) a2.getArray(), new Short[]{(short) 2});
-                Assert.assertArrayEquals((Object[]) a3.getArray(), new Short[]{(short) 3});
-                Assert.assertArrayEquals((Object[]) a4.getArray(), new Short[]{(short) 4, (short)5, (short)6});
+                assertArrayEquals(new Short[]{(short) 1}, (Object[]) a1.getArray());
+                assertArrayEquals(new Short[]{(short) 2}, (Object[]) a2.getArray());
+                assertArrayEquals(new Short[]{(short) 3}, (Object[]) a3.getArray());
+                assertArrayEquals(new Short[]{(short) 4, (short)5, (short)6}, (Object[]) a4.getArray());
             }
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
         });
     }
 
@@ -143,17 +143,15 @@ public class QueryComplexTypeITest extends AbstractITest {
             // Array(UInt8)
             ResultSet rs = statement.executeQuery("SELECT arrayJoin([[1,2,3],[4,5]])");
 
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             Array array1 = rs.getArray(1);
-            Assert.assertNotNull(array1);
-            Assert.assertArrayEquals((Object[]) (array1.getArray()),
-                                     new Short[]{(short) 1, (short) 2, (short) 3});
+            assertNotNull(array1);
+            assertArrayEquals(new Short[]{(short) 1, (short) 2, (short) 3}, (Object[]) (array1.getArray()));
 
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             Array array2 = rs.getArray(1);
-            Assert.assertNotNull(array2);
-            Assert.assertArrayEquals((Object[]) array2.getArray(),
-                                     new Number[]{(short) 4, (short) 5});
+            assertNotNull(array2);
+            assertArrayEquals(new Number[]{(short) 4, (short) 5}, (Object[]) array2.getArray());
         });
     }
 
@@ -166,29 +164,26 @@ public class QueryComplexTypeITest extends AbstractITest {
                 rs =
                 statement.executeQuery("SELECT arrayJoin([[(1,'3'), (2,'4')],[(3,'5')]])");
 
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             Array array1 = rs.getArray(1);
-            Assert.assertNotNull(array1);
+            assertNotNull(array1);
 
             Object[] row1 = (Object[]) array1.getArray();
-            Assert.assertTrue(row1.length == 2);
-            Assert.assertEquals(
-                ((Short) (((ClickHouseStruct) row1[0]).getAttributes()[0])).intValue(), 1);
-            Assert.assertEquals(((ClickHouseStruct) row1[0]).getAttributes()[1], "3");
+            assertEquals(2, row1.length);
+            assertEquals(1, ((Short) (((ClickHouseStruct) row1[0]).getAttributes()[0])).intValue());
+            assertEquals("3", ((ClickHouseStruct) row1[0]).getAttributes()[1]);
 
-            Assert.assertEquals(
-                ((Short) (((ClickHouseStruct) row1[1]).getAttributes()[0])).intValue(), 2);
-            Assert.assertEquals(((ClickHouseStruct) row1[1]).getAttributes()[1], "4");
+            assertEquals(2, ((Short) (((ClickHouseStruct) row1[1]).getAttributes()[0])).intValue());
+            assertEquals("4", ((ClickHouseStruct) row1[1]).getAttributes()[1]);
 
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             Array array2 = rs.getArray(1);
             Object[] row2 = (Object[]) array2.getArray();
-            Assert.assertTrue(row2.length == 1);
-            Assert.assertEquals(
-                ((Short) (((ClickHouseStruct) row2[0]).getAttributes()[0])).intValue(), 3);
-            Assert.assertEquals((((ClickHouseStruct) row2[0]).getAttributes()[1]), "5");
+            assertEquals(1, row2.length);
+            assertEquals(3, ((Short) (((ClickHouseStruct) row2[0]).getAttributes()[0])).intValue());
+            assertEquals("5", (((ClickHouseStruct) row2[0]).getAttributes()[1]));
 
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
         });
     }
 
@@ -203,22 +198,19 @@ public class QueryComplexTypeITest extends AbstractITest {
                     "SELECT [[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]] AS v, toTypeName(v) from numbers(10)");
 
             for (int i = 0; i < 10; i++) {
-                Assert.assertTrue(rs.next());
+                assertTrue(rs.next());
                 Array array1 = rs.getArray(1);
-                Assert.assertNotNull(array1);
+                assertNotNull(array1);
 
                 Double[][] res = new Double[][]{{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
 
                 Object[] arr = (Object[]) (rs.getArray(1).getArray());
-                Assert.assertArrayEquals((Object[]) ((ClickHouseArray) (arr[0])).getArray(),
-                                         res[0]);
-                Assert.assertArrayEquals((Object[]) ((ClickHouseArray) (arr[1])).getArray(),
-                                         res[1]);
-                Assert.assertArrayEquals((Object[]) ((ClickHouseArray) (arr[2])).getArray(),
-                                         res[2]);
-                Assert.assertEquals(rs.getString(2), "Array(Array(Float64))");
+                assertArrayEquals(res[0], (Object[]) ((ClickHouseArray) (arr[0])).getArray());
+                assertArrayEquals(res[1], (Object[]) ((ClickHouseArray) (arr[1])).getArray());
+                assertArrayEquals(res[2], (Object[]) ((ClickHouseArray) (arr[2])).getArray());
+                assertEquals("Array(Array(Float64))", rs.getString(2));
             }
-            Assert.assertFalse(rs.next());
+            assertFalse(rs.next());
 
         });
     }
@@ -231,8 +223,8 @@ public class QueryComplexTypeITest extends AbstractITest {
             long ts = 946659723 * 1000L;
             ResultSet rs = statement.executeQuery("SELECT toDateTime(946659723)");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getTimestamp(1).getTime(), ts);
+            assertTrue(rs.next());
+            assertEquals(ts, rs.getTimestamp(1).getTime());
         });
     }
 
@@ -242,15 +234,14 @@ public class QueryComplexTypeITest extends AbstractITest {
             Statement statement = connection.createStatement();
             ResultSet rs = statement.executeQuery("SELECT (toUInt32(1),'2')");
 
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             Struct struct = (Struct) rs.getObject(1);
-            Assert.assertEquals(struct.getAttributes(), new Object[]{(long) 1, "2"});
+            assertArrayEquals(new Object[]{(long) 1, "2"}, struct.getAttributes());
 
-            Map<String, Class<?>> attrNameWithClass = new LinkedHashMap<String, Class<?>>();
+            Map<String, Class<?>> attrNameWithClass = new LinkedHashMap<>();
             attrNameWithClass.put("_2", String.class);
             attrNameWithClass.put("_1", Long.class);
-            Assert.assertEquals(struct.getAttributes(attrNameWithClass),
-                                new Object[]{"2", (long) 1});
+            assertArrayEquals(new Object[]{"2", (long) 1}, struct.getAttributes(attrNameWithClass));
         });
     }
 
@@ -263,9 +254,9 @@ public class QueryComplexTypeITest extends AbstractITest {
             statement.execute("INSERT INTO test VALUES('a')");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "a");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals("a", rs.getString(1));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }
@@ -279,9 +270,9 @@ public class QueryComplexTypeITest extends AbstractITest {
             statement.execute("INSERT INTO test VALUES('a')");
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "a");
-            Assert.assertFalse(rs.next());
+            assertTrue(rs.next());
+            assertEquals("a", rs.getString(1));
+            assertFalse(rs.next());
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QueryRandomITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QueryRandomITest.java
@@ -1,14 +1,14 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.sql.Connection;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Timestamp;
+
+import static org.junit.Assert.*;
 
 public class QueryRandomITest extends AbstractITest {
 
@@ -33,19 +33,17 @@ public class QueryRandomITest extends AbstractITest {
                 Object time = rs.getObject(5);
                 Object dc = rs.getObject(6);
 
-                Assert.assertEquals(name.getClass(), String.class);
-                Assert.assertEquals(value.getClass(), Long.class);
-                Assert.assertEquals(arr.getClass(), ClickHouseArray.class);
-                Assert.assertEquals(day.getClass(), Date.class);
-                Assert.assertEquals(time.getClass(), Timestamp.class);
-                Assert.assertEquals(dc.getClass(), BigDecimal.class);
+                assertEquals(String.class, name.getClass());
+                assertEquals(Long.class, value.getClass());
+                assertEquals(ClickHouseArray.class, arr.getClass());
+                assertEquals(Date.class, day.getClass());
+                assertEquals(Timestamp.class, time.getClass());
+                assertEquals(BigDecimal.class, dc.getClass());
 
                 i ++;
             }
-            Assert.assertEquals(i , 10000);
+            assertEquals(i , 10000);
             statement.executeQuery("DROP TABLE IF EXISTS test_random");
         }, true);
     }
-
-
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QuerySimpleTypeITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QuerySimpleTypeITest.java
@@ -1,13 +1,13 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
+
+import static org.junit.Assert.*;
 
 public class QuerySimpleTypeITest extends AbstractITest {
 
@@ -18,9 +18,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement.executeQuery(
                     "SELECT toInt8(" + Byte.MIN_VALUE + ") as a , toUInt8(" + Byte.MAX_VALUE + ") as b");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte("a"), Byte.MIN_VALUE);
-            Assert.assertEquals(rs.getByte("b"), Byte.MAX_VALUE);
+            assertTrue(rs.next());
+            assertEquals(Byte.MIN_VALUE, rs.getByte("a"));
+            assertEquals(Byte.MAX_VALUE, rs.getByte("b"));
         });
     }
 
@@ -31,9 +31,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement
                     .executeQuery("SELECT toInt8(" + Byte.MIN_VALUE + "), toUInt8(" + Byte.MAX_VALUE + ")");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getByte(1), Byte.MIN_VALUE);
-            Assert.assertEquals(rs.getByte(2), Byte.MAX_VALUE);
+            assertTrue(rs.next());
+            assertEquals(Byte.MIN_VALUE, rs.getByte(1));
+            assertEquals(Byte.MAX_VALUE, rs.getByte(2));
         });
     }
 
@@ -44,9 +44,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement
                     .executeQuery("SELECT toInt16(" + Short.MIN_VALUE + "), toUInt16(" + Short.MAX_VALUE + ")");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getShort(1), Short.MIN_VALUE);
-            Assert.assertEquals(rs.getShort(2), Short.MAX_VALUE);
+            assertTrue(rs.next());
+            assertEquals(Short.MIN_VALUE, rs.getShort(1));
+            assertEquals(Short.MAX_VALUE, rs.getShort(2));
         });
     }
 
@@ -57,9 +57,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement
                     .executeQuery("SELECT toInt32(" + Integer.MIN_VALUE + "), toUInt32(" + Integer.MAX_VALUE + ")");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), Integer.MIN_VALUE);
-            Assert.assertEquals(rs.getInt(2), Integer.MAX_VALUE);
+            assertTrue(rs.next());
+            assertEquals(Integer.MIN_VALUE, rs.getInt(1));
+            assertEquals(Integer.MAX_VALUE, rs.getInt(2));
         });
     }
 
@@ -69,8 +69,8 @@ public class QuerySimpleTypeITest extends AbstractITest {
             Statement statement = connect.createStatement();
             ResultSet rs = statement.executeQuery("SELECT toUInt32(" + Integer.MAX_VALUE + " + 128)");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getLong(1), Integer.MAX_VALUE * 1L + 128L);
+            assertTrue(rs.next());
+            assertEquals((long) Integer.MAX_VALUE + 128L, rs.getLong(1));
         });
     }
 
@@ -81,9 +81,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement
                     .executeQuery("SELECT toInt64(" + Long.MIN_VALUE + "), toUInt64(" + Long.MAX_VALUE + ")");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getLong(1), Long.MIN_VALUE);
-            Assert.assertEquals(rs.getLong(2), Long.MAX_VALUE);
+            assertTrue(rs.next());
+            assertEquals(Long.MIN_VALUE, rs.getLong(1));
+            assertEquals(Long.MAX_VALUE, rs.getLong(2));
         });
     }
 
@@ -94,9 +94,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement
                     .executeQuery("SELECT toFloat32(" + Float.MIN_VALUE + "), toFloat32(" + Float.MAX_VALUE + ")");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getFloat(1), Float.MIN_VALUE, 0.000000000001);
-            Assert.assertEquals(rs.getFloat(2), Float.MAX_VALUE, 0.000000000001);
+            assertTrue(rs.next());
+            assertEquals(Float.MIN_VALUE, rs.getFloat(1), 0.000000000001);
+            assertEquals(Float.MAX_VALUE, rs.getFloat(2), 0.000000000001);
         });
     }
 
@@ -106,9 +106,9 @@ public class QuerySimpleTypeITest extends AbstractITest {
             Statement statement = connect.createStatement();
             ResultSet rs = statement.executeQuery("SELECT toFloat64(4.9E-32), toFloat64(" + Double.MAX_VALUE + ")");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getDouble(1), Double.MIN_VALUE, 0.000000000001);
-            Assert.assertEquals(rs.getDouble(2), Double.MAX_VALUE, 0.000000000001);
+            assertTrue(rs.next());
+            assertEquals(Double.MIN_VALUE, rs.getDouble(1), 0.000000000001);
+            assertEquals(Double.MAX_VALUE, rs.getDouble(2), 0.000000000001);
         });
     }
 
@@ -118,8 +118,8 @@ public class QuerySimpleTypeITest extends AbstractITest {
             Statement statement = connect.createStatement();
             ResultSet rs = statement.executeQuery("SELECT materialize('01234567-89ab-cdef-0123-456789abcdef')");
 
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getString(1), "01234567-89ab-cdef-0123-456789abcdef");
+            assertTrue(rs.next());
+            assertEquals("01234567-89ab-cdef-0123-456789abcdef", rs.getString(1));
         });
     }
 
@@ -130,23 +130,23 @@ public class QuerySimpleTypeITest extends AbstractITest {
             ResultSet rs = statement.executeQuery(
                     "SELECT number as a1, toString(number) as a2, now() as a3, today() as a4 from numbers(1)");
 
-            Assert.assertTrue(rs.next());
+            assertTrue(rs.next());
             ResultSetMetaData metaData = rs.getMetaData();
-            Assert.assertEquals(metaData.getColumnName(1), "a1");
-            Assert.assertEquals(metaData.getColumnTypeName(1), "UInt64");
-            Assert.assertEquals(metaData.getColumnClassName(1), "java.lang.Long");
+            assertEquals("a1", metaData.getColumnName(1));
+            assertEquals("UInt64", metaData.getColumnTypeName(1));
+            assertEquals("java.lang.Long", metaData.getColumnClassName(1));
 
-            Assert.assertEquals(metaData.getColumnName(2), "a2");
-            Assert.assertEquals(metaData.getColumnTypeName(2), "String");
-            Assert.assertEquals(metaData.getColumnClassName(2), "java.lang.String");
+            assertEquals("a2", metaData.getColumnName(2));
+            assertEquals("String", metaData.getColumnTypeName(2));
+            assertEquals("java.lang.String", metaData.getColumnClassName(2));
 
-            Assert.assertEquals(metaData.getColumnName(3), "a3");
-            Assert.assertEquals(metaData.getColumnTypeName(3), "DateTime");
-            Assert.assertEquals(metaData.getColumnClassName(3), "java.sql.Timestamp");
+            assertEquals("a3", metaData.getColumnName(3));
+            assertEquals("DateTime", metaData.getColumnTypeName(3));
+            assertEquals("java.sql.Timestamp", metaData.getColumnClassName(3));
 
-            Assert.assertEquals(metaData.getColumnName(4), "a4");
-            Assert.assertEquals(metaData.getColumnTypeName(4), "Date");
-            Assert.assertEquals(metaData.getColumnClassName(4), "java.sql.Date");
+            assertEquals("a4", metaData.getColumnName(4));
+            assertEquals("Date", metaData.getColumnTypeName(4));
+            assertEquals("java.sql.Date", metaData.getColumnClassName(4));
         });
     }
 
@@ -160,15 +160,15 @@ public class QuerySimpleTypeITest extends AbstractITest {
 
                 try (PreparedStatement ps = connection.prepareStatement("INSERT INTO test VALUES(?)")) {
                     ps.setString(1, "test_string with ' character");
-                    Assert.assertEquals(1, ps.executeUpdate());
+                    assertEquals(1, ps.executeUpdate());
                 }
 
                 try (PreparedStatement ps = connection.prepareStatement("SELECT * FROM test WHERE test=?")) {
                     ps.setString(1, "test_string with ' character");
                     try (ResultSet rs = ps.executeQuery()) {
-                        Assert.assertTrue(rs.next());
-                        Assert.assertEquals(rs.getString(1), "test_string with ' character");
-                        Assert.assertFalse(rs.next());
+                        assertTrue(rs.next());
+                        assertEquals("test_string with ' character", rs.getString(1));
+                        assertFalse(rs.next());
                     }
                 }
                 statement.executeQuery("DROP TABLE IF EXISTS test");

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ResultSetMetadataITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ResultSetMetadataITest.java
@@ -1,12 +1,12 @@
 package com.github.housepower.jdbc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
+
+import static org.junit.Assert.*;
 
 public class ResultSetMetadataITest extends AbstractITest {
 
@@ -21,12 +21,12 @@ public class ResultSetMetadataITest extends AbstractITest {
             ResultSet rs = statement.executeQuery("SELECT * FROM test");
             ResultSetMetaData metadata =  rs.getMetaData();
 
-            Assert.assertEquals(metadata.getTableName(1), "test");
-            Assert.assertEquals(metadata.getCatalogName(1), "default");
+            assertEquals("test", metadata.getTableName(1));
+            assertEquals("default", metadata.getCatalogName(1));
 
-            Assert.assertEquals(metadata.getPrecision(1), 3);
-            Assert.assertEquals(metadata.getPrecision(2), 19);
-            Assert.assertEquals(metadata.getPrecision(3), 3);
+            assertEquals(3, metadata.getPrecision(1));
+            assertEquals(19, metadata.getPrecision(2));
+            assertEquals(3, metadata.getPrecision(3));
             statement.executeQuery("DROP TABLE IF EXISTS test");
         });
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/SQLLexerITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/SQLLexerITest.java
@@ -2,88 +2,87 @@ package com.github.housepower.jdbc;
 
 import com.github.housepower.jdbc.misc.SQLLexer;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class SQLLexerITest extends AbstractITest {
 
     @Test
     public void successfullyNumber() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "123");
-        Assert.assertEquals(sqlLexer.numberLiteral(), 123L);
+        assertEquals(123L, sqlLexer.numberLiteral());
     }
 
     @Test
     public void successfullyNegativeNumber() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "-123");
-        Assert.assertEquals(sqlLexer.numberLiteral(), -123L);
+        assertEquals(-123L, sqlLexer.numberLiteral());
     }
 
     @Test
     public void successfullyDoubleNumber() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "-123.0 3E2");
-        Assert.assertEquals(sqlLexer.numberLiteral(), -123.0);
-        Assert.assertEquals(sqlLexer.numberLiteral(), 300.0);
+        assertEquals(-123.0, sqlLexer.numberLiteral());
+        assertEquals(300.0, sqlLexer.numberLiteral());
     }
 
     @Test
     public void successfullyNumberInHexa() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "-0xfp2 0xfp2 0xfp1 0xfp0 0xf -0xf");
-        Assert.assertEquals(sqlLexer.numberLiteral(), -60.0);
-        Assert.assertEquals(sqlLexer.numberLiteral(), 60.0d);
-        Assert.assertEquals(sqlLexer.numberLiteral(), 30.0);
-        Assert.assertEquals(sqlLexer.numberLiteral(), 15.0);
-        Assert.assertEquals(sqlLexer.numberLiteral(), 15L);
-        Assert.assertEquals(sqlLexer.numberLiteral(), -15L);
+        assertEquals(-60.0, sqlLexer.numberLiteral());
+        assertEquals(60.0d, sqlLexer.numberLiteral());
+        assertEquals(30.0, sqlLexer.numberLiteral());
+        assertEquals(15.0, sqlLexer.numberLiteral());
+        assertEquals(15L, sqlLexer.numberLiteral());
+        assertEquals(-15L, sqlLexer.numberLiteral());
     }
 
     @Test
     public void successfullyNumberInBinary() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "0b111 -0b111 +0b111");
-        Assert.assertEquals(sqlLexer.numberLiteral(), 7L);
-        Assert.assertEquals(sqlLexer.numberLiteral(), -7L);
-        Assert.assertEquals(sqlLexer.numberLiteral(), 7L);
+        assertEquals(7L, sqlLexer.numberLiteral());
+        assertEquals(-7L, sqlLexer.numberLiteral());
+        assertEquals(7L, sqlLexer.numberLiteral());
     }
 
     @Test
     public void successfullyLong() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "123 +123  -123    -1");
-        Assert.assertEquals(sqlLexer.longLiteral(), 123L);
-        Assert.assertEquals(sqlLexer.longLiteral(), 123L);
-        Assert.assertEquals(sqlLexer.longLiteral(), -123L);
-        Assert.assertEquals(sqlLexer.longLiteral(), -1L);
+        assertEquals(123L, sqlLexer.longLiteral());
+        assertEquals(123L, sqlLexer.longLiteral());
+        assertEquals(-123L, sqlLexer.longLiteral());
+        assertEquals(-1L, sqlLexer.longLiteral());
     }
 
     @Test
     public void successfullyStringLiteral() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "'this is a quoted message'");
-        Assert.assertEquals(sqlLexer.stringLiteral().toString(), "this is a quoted message");
-
+        assertEquals("this is a quoted message", sqlLexer.stringLiteral().toString());
     }
 
     @Test
     public void successfullyStringLiteralWithSingleQuote() throws Exception {
-        String s =  "'this is a message with \\' char'";
-        SQLLexer sqlLexer = new SQLLexer(0,s);
+        String s = "'this is a message with \\' char'";
+        SQLLexer sqlLexer = new SQLLexer(0, s);
         System.out.println(s);
-        Assert.assertEquals("this is a message with \\' char", sqlLexer.stringLiteral().toString());
+        assertEquals("this is a message with \\' char", sqlLexer.stringLiteral().toString());
     }
 
     @Test
     public void successfullyBareWord() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "_askes String");
-        Assert.assertEquals(sqlLexer.bareWord().toString(), "_askes");
-        Assert.assertEquals(sqlLexer.bareWord().toString(), "String");
-
+        assertEquals("_askes", sqlLexer.bareWord().toString());
+        assertEquals("String", sqlLexer.bareWord().toString());
     }
 
     @Test
     public void successfullyDateTime() throws Exception {
         SQLLexer sqlLexer = new SQLLexer(0, "h DateTime('Asia/Shanghai')");
-        Assert.assertEquals(sqlLexer.bareWord().toString(), "h");
-        Assert.assertEquals(sqlLexer.bareWord().toString(), "DateTime");
-        Assert.assertEquals(sqlLexer.character(), '(');
-        Assert.assertEquals(sqlLexer.stringLiteral().toString(), "Asia/Shanghai");
-        Assert.assertEquals(sqlLexer.character(), ')');
+        assertEquals("h", sqlLexer.bareWord().toString());
+        assertEquals("DateTime", sqlLexer.bareWord().toString());
+        assertEquals('(', sqlLexer.character());
+        assertEquals("Asia/Shanghai", sqlLexer.stringLiteral().toString());
+        assertEquals(')', sqlLexer.character());
     }
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/AbstractIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/AbstractIBenchmark.java
@@ -22,11 +22,9 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 public class AbstractIBenchmark {
     private static final int
-        SERVER_PORT =
-        Integer.valueOf(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
+        SERVER_PORT = Integer.parseInt(System.getProperty("CLICK_HOUSE_SERVER_PORT", "9000"));
     private static final int
-        SERVER_HTTP_PORT =
-        Integer.valueOf(System.getProperty("CLICK_HOUSE_SERVER_HTTP_PORT", "8123"));
+        SERVER_HTTP_PORT = Integer.parseInt(System.getProperty("CLICK_HOUSE_SERVER_HTTP_PORT", "8123"));
 
     private final Driver httpDriver = new ru.yandex.clickhouse.ClickHouseDriver();
     private final Driver nativeDriver = new com.github.housepower.jdbc.ClickHouseDriver();
@@ -64,11 +62,8 @@ public class AbstractIBenchmark {
                 DriverManager.registerDriver(nativeDriver);
                 break;
         }
-        Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1:" + port);
-        try {
+        try (Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1:" + port)) {
             withConnection.apply(connection);
-        } finally {
-            connection.close();
         }
     }
 

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/AbstractInsertIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/AbstractInsertIBenchmark.java
@@ -31,11 +31,11 @@ public class AbstractInsertIBenchmark extends AbstractIBenchmark{
         String testTable = "test_" + tableId;
         Statement stmt = connection.createStatement();
         stmt.executeQuery("DROP TABLE IF EXISTS " + testTable);
-        String createSQL = "CREATE TABLE " + testTable + " (";
+        StringBuilder createSQL = new StringBuilder("CREATE TABLE " + testTable + " (");
         for (int i = 0; i < columnNum; i++) {
-            createSQL += "col_" + i + " "  + columnType ;
+            createSQL.append("col_").append(i).append(" ").append(columnType);
             if (i + 1 != columnNum) {
-                createSQL += ",\n";
+                createSQL.append(",\n");
             }
         }
         stmt.executeQuery(createSQL + ")Engine = Log");

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/ProfileBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/ProfileBenchmark.java
@@ -1,8 +1,5 @@
 package com.github.housepower.jdbc.benchmark;
 
-/**
- */
-
 import org.junit.Test;
 
 import java.sql.ResultSet;
@@ -12,8 +9,8 @@ import java.util.Locale;
 /**
  */
 public class ProfileBenchmark extends AbstractIBenchmark{
-    private static long n = 10000000;
-    private static long statsOutputFrequency = 10;
+    private static final long n = 10000000;
+    private static final long statsOutputFrequency = 10;
 
     public WithConnection benchSelectSumInt = connection -> {
         Statement statement = connection.createStatement();

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/Profiler.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/Profiler.java
@@ -6,9 +6,9 @@ import java.util.Locale;
  * From https://gist.github.com/gothug/3b35fe0cec302efe6f8314a9cab8865e
  */
 public class Profiler {
-    public class ElapsedTime {
-        private long elapsedTimeMillis;
-        private long elapsedTimeDeltaMillis;
+    public static class ElapsedTime {
+        private final long elapsedTimeMillis;
+        private final long elapsedTimeDeltaMillis;
 
         public long getElapsedTimeMillis() { return elapsedTimeMillis; }
         public long getElapsedTimeDeltaMillis() { return elapsedTimeDeltaMillis; }
@@ -76,6 +76,7 @@ public class Profiler {
         String totalElapsedMillisStr = fixedLengthString(String.valueOf(elapsedMillis), 6);
         String millisPassedFromLastLogStr = fixedLengthString(String.valueOf(elapsedDeltaMillis), 6);
         System.out.println(percentCompleteStr + " Total memory (MB): " + totalMemoryStr + ", used memory (MB): "
-                           + usedMemoryStr + ", time elapsed: " + totalElapsedMillisStr + "(+" + millisPassedFromLastLogStr + " ms)");
+                           + usedMemoryStr + ", time elapsed: " + totalElapsedMillisStr
+                           + "(+" + millisPassedFromLastLogStr + " ms)");
     }
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/RowBinaryDoubleIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/RowBinaryDoubleIBenchmark.java
@@ -14,7 +14,7 @@ import ru.yandex.clickhouse.domain.ClickHouseFormat;
 /**
  */
 public class RowBinaryDoubleIBenchmark extends AbstractInsertIBenchmark {
-    private String columnType = "Float64";
+    private final String columnType = "Float64";
 
     @Benchmark
     @Test

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/RowBinaryIntIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/RowBinaryIntIBenchmark.java
@@ -14,7 +14,7 @@ import ru.yandex.clickhouse.domain.ClickHouseFormat;
 /**
  */
 public class RowBinaryIntIBenchmark extends AbstractInsertIBenchmark {
-    private String columnType = "Int32";
+    private final String columnType = "Int32";
 
     @Benchmark
     @Test

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/RowBinaryStringIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/RowBinaryStringIBenchmark.java
@@ -14,7 +14,7 @@ import ru.yandex.clickhouse.domain.ClickHouseFormat;
 /**
  */
 public class RowBinaryStringIBenchmark extends AbstractInsertIBenchmark{
-    private String columnType = "String";
+    private final String columnType = "String";
 
     @Benchmark
     @Test

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/WideColumnDoubleInsertIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/WideColumnDoubleInsertIBenchmark.java
@@ -24,26 +24,23 @@ public class WideColumnDoubleInsertIBenchmark extends AbstractInsertIBenchmark {
         withConnection(benchInsert, ConnectionType.HTTP);
     }
 
-    public WithConnection benchInsert = new WithConnection(){
-        @Override
-        public void apply(Connection connection) throws Exception {
-            wideColumnPrepare(connection, "Float64");
+    public WithConnection benchInsert = connection -> {
+        wideColumnPrepare(connection, "Float64");
 
-            String params = Strings.repeat("?, ", columnNum);
-            PreparedStatement pstmt = connection.prepareStatement("INSERT INTO "  + getTableName() +" values("   + params.substring(0, params.length()-2) + ")");
+        String params = Strings.repeat("?, ", columnNum);
+        PreparedStatement pstmt = connection.prepareStatement("INSERT INTO "  + getTableName() +" values("   + params.substring(0, params.length()-2) + ")");
 
 
-            for (int i = 0; i < batchSize; i++) {
-                for (int j = 0; j < columnNum; j++ ) {
-                    pstmt.setDouble(j + 1, j + 1.2);
-                }
-                pstmt.addBatch();
+        for (int i = 0; i < batchSize; i++) {
+            for (int j = 0; j < columnNum; j++ ) {
+                pstmt.setDouble(j + 1, j + 1.2);
             }
-            int []res = pstmt.executeBatch();
-            Assert.assertEquals(res.length, batchSize);
-
-            wideColumnAfter(connection);
+            pstmt.addBatch();
         }
+        int []res = pstmt.executeBatch();
+        Assert.assertEquals(res.length, batchSize);
+
+        wideColumnAfter(connection);
     };
 
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/WideColumnIntInsertIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/WideColumnIntInsertIBenchmark.java
@@ -24,26 +24,23 @@ public class WideColumnIntInsertIBenchmark extends AbstractInsertIBenchmark {
         withConnection(benchInsert, ConnectionType.HTTP);
     }
 
-    public WithConnection benchInsert = new WithConnection(){
-        @Override
-        public void apply(Connection connection) throws Exception {
-            wideColumnPrepare(connection, "Int32");
+    public WithConnection benchInsert = connection -> {
+        wideColumnPrepare(connection, "Int32");
 
-            String params = Strings.repeat("?, ", columnNum);
-            PreparedStatement pstmt = connection.prepareStatement("INSERT INTO "  + getTableName() +" values("   + params.substring(0, params.length()-2) + ")");
+        String params = Strings.repeat("?, ", columnNum);
+        PreparedStatement pstmt = connection.prepareStatement("INSERT INTO "  + getTableName() +" values("   + params.substring(0, params.length()-2) + ")");
 
 
-            for (int i = 0; i < batchSize; i++) {
-                for (int j = 0; j < columnNum; j++ ) {
-                    pstmt.setInt(j + 1, j + 1);
-                }
-                pstmt.addBatch();
+        for (int i = 0; i < batchSize; i++) {
+            for (int j = 0; j < columnNum; j++ ) {
+                pstmt.setInt(j + 1, j + 1);
             }
-            int []res = pstmt.executeBatch();
-            Assert.assertEquals(res.length, batchSize);
-
-            wideColumnAfter(connection);
+            pstmt.addBatch();
         }
+        int []res = pstmt.executeBatch();
+        Assert.assertEquals(res.length, batchSize);
+
+        wideColumnAfter(connection);
     };
 
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/WideColumnStringInsertIBenchmark.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/benchmark/WideColumnStringInsertIBenchmark.java
@@ -34,23 +34,20 @@ public class WideColumnStringInsertIBenchmark extends AbstractInsertIBenchmark {
         withConnection(benchInsert, ConnectionType.HTTP);
     }
 
-    public WithConnection benchInsert = new WithConnection(){
-        @Override
-        public void apply(Connection connection) throws Exception {
-            wideColumnPrepare(connection, "String");
-            String params = Strings.repeat("?, ", columnNum);
-            PreparedStatement pstmt = connection.prepareStatement("INSERT INTO "  + getTableName() +" values("   + params.substring(0, params.length()-2) + ")");
+    public WithConnection benchInsert = connection -> {
+        wideColumnPrepare(connection, "String");
+        String params = Strings.repeat("?, ", columnNum);
+        PreparedStatement pstmt = connection.prepareStatement("INSERT INTO "  + getTableName() +" values("   + params.substring(0, params.length()-2) + ")");
 
-            for (int i = 0; i < batchSize; i++) {
-                for (int j = 0; j < columnNum; j++ ) {
-                    pstmt.setString(j + 1, j + 1 + "");
-                }
-                pstmt.addBatch();
+        for (int i = 0; i < batchSize; i++) {
+            for (int j = 0; j < columnNum; j++ ) {
+                pstmt.setString(j + 1, j + 1 + "");
             }
-            int []res = pstmt.executeBatch();
-            Assert.assertEquals(res.length, batchSize);
-            wideColumnAfter(connection);
+            pstmt.addBatch();
         }
+        int []res = pstmt.executeBatch();
+        Assert.assertEquals(res.length, batchSize);
+        wideColumnAfter(connection);
     };
 
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/buffer/SocketBuffedReaderTest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/buffer/SocketBuffedReaderTest.java
@@ -7,7 +7,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class SocketBuffedReaderTest {
@@ -37,19 +36,16 @@ public class SocketBuffedReaderTest {
         final AtomicInteger position = new AtomicInteger(0);
 
         Mockito.when(in.read(Mockito.any(byte[].class), Mockito.anyInt(), Mockito.anyInt()))
-            .thenAnswer(new Answer<Integer>() {
-                @Override
-                public Integer answer(InvocationOnMock invocation) throws Throwable {
-                    int offset = invocation.getArgumentAt(1, int.class);
-                    byte[] bytes = invocation.getArgumentAt(0, byte[].class);
+            .thenAnswer((Answer<Integer>) invocation -> {
+                int offset = invocation.getArgumentAt(1, int.class);
+                byte[] bytes = invocation.getArgumentAt(0, byte[].class);
 
-                    byte[] fragment = fragments[position.getAndIncrement()];
-                    if (bytes.length < fragment.length) {
-                        throw new IOException("Failed test case.");
-                    }
-                    System.arraycopy(fragment, 0, bytes, offset, fragment.length);
-                    return fragment.length;
+                byte[] fragment = fragments[position.getAndIncrement()];
+                if (bytes.length < fragment.length) {
+                    throw new IOException("Failed test case.");
                 }
+                System.arraycopy(fragment, 0, bytes, offset, fragment.length);
+                return fragment.length;
             });
 
         return in;


### PR DESCRIPTION
## What's changes in this PR?

- migrate to `java.time`, close #164
- improve code style, respect parameters semantic of `assertEquals(Object expected, Object actual)`

## Others

@sundy-li Please respect parameters semantic of `assertEquals(Object expected, Object actual)`, all exists code should be fixed.
