### PR TITLE
(build) debug profile

### DIFF
--- a/clickhouse-native-jdbc-shaded/pom.xml
+++ b/clickhouse-native-jdbc-shaded/pom.xml
@@ -73,6 +73,7 @@
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>LICENSE</exclude>
+                                        <exclude>simplelogger.properties</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -82,4 +83,49 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>debug</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                    <optional>false</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                    <optional>false</optional>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <configuration>
+                                    <artifactSet>
+                                        <excludes>
+                                            <exclude>not-exist:*</exclude>
+                                        </excludes>
+                                    </artifactSet>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>LICENSE</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/clickhouse-native-jdbc-shaded/src/main/resources/simplelogger.properties
+++ b/clickhouse-native-jdbc-shaded/src/main/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+org.slf4j.simpleLogger.defaultLogLevel=TRACE
+org.slf4j.simpleLogger.log.com.github.housepower.jdbc.connect.NativeClient=TRACE
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showShortLogName=true
+org.slf4j.simpleLogger.logFile=/tmp/clickhouse-native-jdbc.log

--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,9 @@
 
     <profiles>
         <profile>
+            <id>debug</id>
+        </profile>
+        <profile>
             <id>benchmark</id>
         </profile>
         <profile>


### PR DESCRIPTION
## What changes in this PR?

Add `debug` profile for print log into file `/tmp/clickhouse-native-jdbc.log`.

Build using `mvn clean package -DskipTests -Pdebug`, then get a `clickhouse-native-jdbc-shaded-2.5.0-SNAPSHOT.jar` which will print log into file `/tmp/clickhouse-native-jdbc.log`, it's more useful for debug with `DataGrip` or `DBeaver`.

No impact on normal build process which run without `-Pdebug` option.