### PR TITLE
Set ErrorCode correctly, so that we can use SQLException without downcast to ClickHouseSQLException

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseSQLException.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseSQLException.java
@@ -18,18 +18,14 @@ import java.sql.SQLException;
 
 public class ClickHouseSQLException extends SQLException {
 
-    private final int code;
-
     public ClickHouseSQLException(int code, String message) {
         this(code, message, null);
     }
 
     public ClickHouseSQLException(int code, String message, Throwable cause) {
-        super(message, cause);
-        this.code = code;
+        super(message, null, code, cause);
     }
-
     public int getCode() {
-        return code;
+        return getErrorCode();
     }
 }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickHouseSQLExceptionITTest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickHouseSQLExceptionITTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.housepower.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class ClickHouseSQLExceptionITTest extends AbstractITest {
+
+    @Test
+    public void errorCodeShouldBeAssigned() throws Exception {
+        withNewConnection(connection -> {
+            Statement statement = connection.createStatement();
+            try {
+                statement.executeQuery("DROP TABLE test");
+            } catch (SQLException e) {
+                assertTrue(e instanceof ClickHouseSQLException);
+                assertNotEquals(0, e.getErrorCode());
+                assertEquals(e.getErrorCode(), ((ClickHouseSQLException) e).getCode());
+            }
+        });
+    }
+}

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickHouseSQLExceptionITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickHouseSQLExceptionITest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-public class ClickHouseSQLExceptionITTest extends AbstractITest {
+public class ClickHouseSQLExceptionITest extends AbstractITest {
 
     @Test
     public void errorCodeShouldBeAssigned() throws Exception {


### PR DESCRIPTION
In some cases, we don't want to introduce an explicit dependency on a concrete clickhouse driver. 

For example, we would use yandex driver for cases where native jdbc driver doesn't support it, but we want to unify the error handling.