### PR TITLE
Fix columnIdx in convertToCkDataType

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/data/Block.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/data/Block.java
@@ -98,12 +98,12 @@ public class Block {
         }
     }
 
-    public void setConstObject(int columnIdx, Object object) {
+    public void setObject(int columnIdx, Object object) {
         rowData[columnIdx] = object;
     }
 
-    public void setPlaceholderObject(int placeholderIdx, Object object) {
-        rowData[placeholderIndexes[placeholderIdx]] = object;
+    public int paramIdx2ColumnIdx(int paramIdx) {
+        return placeholderIndexes[paramIdx];
     }
 
     public void incPlaceholderIndexes(int columnIdx) {
@@ -123,23 +123,25 @@ public class Block {
         }
     }
 
-    public IColumn getColumnByPosition(int position) throws SQLException {
-        Validate.isTrue(position < columns.length,
-                "Position " + position +
+    // idx start with 0
+    public IColumn getColumn(int columnIdx) throws SQLException {
+        Validate.isTrue(columnIdx < columns.length,
+                "Position " + columnIdx +
                         " is out of bound in Block.getByPosition, max position = " + (columns.length - 1));
-        return columns[position];
+        return columns[columnIdx];
     }
 
+    // position start with 1
     public int getPositionByName(String columnName) throws SQLException {
         Validate.isTrue(nameAndPositions.containsKey(columnName), "Column '" + columnName + "' does not exist");
         return nameAndPositions.get(columnName);
     }
 
-    public Object getObject(int columnIndex) throws SQLException {
-        Validate.isTrue(columnIndex < columns.length,
-                "Position " + columnIndex +
+    public Object getObject(int columnIdx) throws SQLException {
+        Validate.isTrue(columnIdx < columns.length,
+                "Position " + columnIdx +
                         " is out of bound in Block.getByPosition, max position = " + (columns.length - 1));
-        return rowData[columnIndex];
+        return rowData[columnIdx];
     }
 
     public void initWriteBuffer() {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseResultSet.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseResultSet.java
@@ -151,8 +151,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public boolean getBoolean(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public boolean getBoolean(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return false;
         }
@@ -161,8 +161,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public byte getByte(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public byte getByte(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return 0;
         }
@@ -170,8 +170,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public short getShort(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public short getShort(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return 0;
         }
@@ -179,8 +179,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public int getInt(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public int getInt(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return 0;
         }
@@ -188,8 +188,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public long getLong(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public long getLong(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return 0;
         }
@@ -197,8 +197,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public float getFloat(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public float getFloat(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return 0;
         }
@@ -206,8 +206,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public double getDouble(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public double getDouble(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return 0;
         }
@@ -215,8 +215,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public Timestamp getTimestamp(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public Timestamp getTimestamp(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return null;
         }
@@ -225,8 +225,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public Timestamp getTimestamp(int index, Calendar cal) throws SQLException {
-        Object data = getInternalObject(index);
+    public Timestamp getTimestamp(int position, Calendar cal) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return null;
         }
@@ -235,16 +235,16 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public Date getDate(int index) throws SQLException {
-        LocalDate date = (LocalDate) getInternalObject(index);
+    public Date getDate(int position) throws SQLException {
+        LocalDate date = (LocalDate) getInternalObject(position);
         if (date == null)
             return null;
         return Date.valueOf(date);
     }
 
     @Override
-    public BigDecimal getBigDecimal(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public BigDecimal getBigDecimal(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return null;
         }
@@ -255,8 +255,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public String getString(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public String getString(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return null;
         }
@@ -265,8 +265,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public byte[] getBytes(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public byte[] getBytes(int position) throws SQLException {
+        Object data = getInternalObject(position);
         if (data == null) {
             return null;
         }
@@ -277,8 +277,8 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public URL getURL(int index) throws SQLException {
-        String data = this.getString(index);
+    public URL getURL(int position) throws SQLException {
+        String data = this.getString(position);
         if (data == null) {
             return null;
         }
@@ -290,14 +290,14 @@ public class ClickHouseResultSet implements SQLResultSet {
     }
 
     @Override
-    public Array getArray(int index) throws SQLException {
-        Object data = getInternalObject(index);
+    public Array getArray(int position) throws SQLException {
+        Object data = getInternalObject(position);
         return (Array) data;
     }
 
     @Override
-    public Object getObject(int index) throws SQLException {
-        Object obj = getInternalObject(index);
+    public Object getObject(int position) throws SQLException {
+        Object obj = getInternalObject(position);
         if (obj == null) {
             return null;
         }
@@ -314,12 +314,12 @@ public class ClickHouseResultSet implements SQLResultSet {
         return obj;
     }
 
-    private Object getInternalObject(int index) throws SQLException {
-        LOG.trace("get object at row: {}, column: {} from block with column count: {}, row count: {}",
-                currentRowNum, index, currentBlock.columnCnt(), currentBlock.rowCnt());
+    private Object getInternalObject(int position) throws SQLException {
+        LOG.trace("get object at row: {}, column position: {} from block with column count: {}, row count: {}",
+                currentRowNum, position, currentBlock.columnCnt(), currentBlock.rowCnt());
         Validate.isTrue(currentRowNum >= 0 && currentRowNum < currentBlock.rowCnt(),
                 "No row information was obtained. You must call ResultSet.next() before that.");
-        IColumn column = (lastFetchBlock = currentBlock).getColumn((lastFetchColumnIdx = index - 1));
+        IColumn column = (lastFetchBlock = currentBlock).getColumn((lastFetchColumnIdx = position - 1));
         return column.value((lastFetchRowIdx = currentRowNum));
     }
 

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseResultSet.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseResultSet.java
@@ -319,7 +319,7 @@ public class ClickHouseResultSet implements SQLResultSet {
                 currentRowNum, index, currentBlock.columnCnt(), currentBlock.rowCnt());
         Validate.isTrue(currentRowNum >= 0 && currentRowNum < currentBlock.rowCnt(),
                 "No row information was obtained. You must call ResultSet.next() before that.");
-        IColumn column = (lastFetchBlock = currentBlock).getColumnByPosition((lastFetchColumnIdx = index - 1));
+        IColumn column = (lastFetchBlock = currentBlock).getColumn((lastFetchColumnIdx = index - 1));
         return column.value((lastFetchRowIdx = currentRowNum));
     }
 
@@ -381,7 +381,7 @@ public class ClickHouseResultSet implements SQLResultSet {
         Validate.isTrue(lastFetchBlock != null, "Please call Result.next()");
         Validate.isTrue(lastFetchColumnIdx >= 0, "Please call Result.getXXX()");
         Validate.isTrue(lastFetchRowIdx >= 0 && lastFetchRowIdx < lastFetchBlock.rowCnt(), "Please call Result.next()");
-        return lastFetchBlock.getColumnByPosition(lastFetchColumnIdx).value(lastFetchRowIdx) == null;
+        return lastFetchBlock.getColumn(lastFetchColumnIdx).value(lastFetchRowIdx) == null;
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseResultSetMetaData.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseResultSetMetaData.java
@@ -45,7 +45,7 @@ public class ClickHouseResultSetMetaData implements SQLResultSetMetaData {
 
     @Override
     public int getColumnType(int index) throws SQLException {
-        return header.getColumnByPosition(index - 1).type().sqlTypeId();
+        return header.getColumn(index - 1).type().sqlTypeId();
     }
 
     @Override
@@ -70,12 +70,12 @@ public class ClickHouseResultSetMetaData implements SQLResultSetMetaData {
 
     @Override
     public String getColumnTypeName(int column) throws SQLException {
-        return header.getColumnByPosition(column - 1).type().name();
+        return header.getColumn(column - 1).type().name();
     }
 
     @Override
     public String getColumnClassName(int column) throws SQLException {
-        return header.getColumnByPosition(column - 1).type().jdbcJavaType().getName();
+        return header.getColumn(column - 1).type().jdbcJavaType().getName();
     }
 
     @Override
@@ -85,28 +85,28 @@ public class ClickHouseResultSetMetaData implements SQLResultSetMetaData {
 
     @Override
     public String getColumnLabel(int index) throws SQLException {
-        return header.getColumnByPosition(index - 1).name();
+        return header.getColumn(index - 1).name();
     }
 
     @Override
     public int isNullable(int index) throws SQLException {
-        return (header.getColumnByPosition(index - 1).type() instanceof DataTypeNullable) ?
+        return (header.getColumn(index - 1).type() instanceof DataTypeNullable) ?
             ResultSetMetaData.columnNullable : ResultSetMetaData.columnNoNulls;
     }
 
     @Override
     public boolean isSigned(int index) throws SQLException {
-        return header.getColumnByPosition(index - 1).type().isSigned();
+        return header.getColumn(index - 1).type().isSigned();
     }
 
     @Override
     public int getPrecision(int column) throws SQLException {
-        return header.getColumnByPosition(column - 1).type().getPrecision();
+        return header.getColumn(column - 1).type().getPrecision();
     }
 
     @Override
     public int getScale(int column) throws SQLException {
-        return header.getColumnByPosition(column - 1).type().getScale();
+        return header.getColumn(column - 1).type().getScale();
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedInsertStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedInsertStatement.java
@@ -14,6 +14,7 @@
 
 package com.github.housepower.jdbc.statement;
 
+import com.github.housepower.data.IColumn;
 import com.github.housepower.jdbc.ClickHouseArray;
 import com.github.housepower.jdbc.ClickHouseConnection;
 import com.github.housepower.jdbc.ClickHouseSQLException;
@@ -85,11 +86,13 @@ public class ClickHousePreparedInsertStatement extends AbstractPreparedStatement
         initBlockIfPossible();
     }
 
-    // parameterIndex start with 1
+    // paramPosition start with 1
     @Override
-    public void setObject(int idx, Object x) throws SQLException {
+    public void setObject(int paramPosition, Object x) throws SQLException {
         initBlockIfPossible();
-        block.setPlaceholderObject(idx - 1, convertToCkDataType(block.getColumnByPosition(idx - 1).type(), x));
+        int columnIdx = block.paramIdx2ColumnIdx(paramPosition - 1);
+        IColumn column = block.getColumn(columnIdx);
+        block.setObject(columnIdx, convertToCkDataType(column.type(), x));
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/stream/ValuesInputFormat.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/stream/ValuesInputFormat.java
@@ -47,7 +47,7 @@ public class ValuesInputFormat implements InputFormat {
                     Validate.isTrue(lexer.character() == ',');
                 }
                 constIdxFlags.set(columnIdx);
-                block.setConstObject(columnIdx, block.getColumnByPosition(columnIdx).type().deserializeText(lexer));
+                block.setObject(columnIdx, block.getColumn(columnIdx).type().deserializeText(lexer));
             }
             Validate.isTrue(lexer.character() == ')');
             block.appendRow();

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/stream/ValuesWithParametersInputFormat.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/stream/ValuesWithParametersInputFormat.java
@@ -43,7 +43,7 @@ public class ValuesWithParametersInputFormat implements InputFormat {
                 lexer.character();
             } else {
                 constIdxFlags.set(columnIdx);
-                block.setConstObject(columnIdx, block.getColumnByPosition(columnIdx).type().deserializeText(lexer));
+                block.setObject(columnIdx, block.getColumn(columnIdx).type().deserializeText(lexer));
             }
         }
 


### PR DESCRIPTION
It's a correctness issue, and there are minor refactor in addition to bug fix.

There are some `index` start with `1` in JDBC interface definition which constantly confusing us, and I made a change in this PR to clarify that term `index` should always start with `0` in our codebase, and use term `position` to present those stuffs start with `1`.