### PR TITLE
support config client name

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
@@ -14,22 +14,22 @@
 
 package com.github.housepower.jdbc;
 
-import com.github.housepower.client.SessionState;
 import com.github.housepower.client.NativeClient;
 import com.github.housepower.client.NativeContext;
+import com.github.housepower.client.SessionState;
 import com.github.housepower.data.Block;
 import com.github.housepower.data.DataTypeFactory;
-import com.github.housepower.misc.Validate;
-import com.github.housepower.protocol.HelloResponse;
-import com.github.housepower.stream.QueryResult;
-import com.github.housepower.settings.ClickHouseConfig;
-import com.github.housepower.settings.ClickHouseDefines;
 import com.github.housepower.jdbc.statement.ClickHousePreparedInsertStatement;
 import com.github.housepower.jdbc.statement.ClickHousePreparedQueryStatement;
 import com.github.housepower.jdbc.statement.ClickHouseStatement;
 import com.github.housepower.jdbc.wrapper.SQLConnection;
 import com.github.housepower.log.Logger;
 import com.github.housepower.log.LoggerFactory;
+import com.github.housepower.misc.Validate;
+import com.github.housepower.protocol.HelloResponse;
+import com.github.housepower.settings.ClickHouseConfig;
+import com.github.housepower.settings.ClickHouseDefines;
+import com.github.housepower.stream.QueryResult;
 
 import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
@@ -37,7 +37,6 @@ import java.sql.*;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
@@ -313,7 +312,7 @@ public class ClickHouseConnection implements SQLConnection {
     private static NativeContext.ClientContext clientContext(NativeClient nativeClient, ClickHouseConfig configure) throws SQLException {
         Validate.isTrue(nativeClient.address() instanceof InetSocketAddress);
         InetSocketAddress address = (InetSocketAddress) nativeClient.address();
-        String clientName = String.format(Locale.ROOT, "%s %s", ClickHouseDefines.NAME, "client");
+        String clientName = configure.clientName();
         String initialAddress = "[::ffff:127.0.0.1]:0";
         return new NativeContext.ClientContext(initialAddress, address.getHostName(), clientName);
     }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/settings/SettingKey.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/settings/SettingKey.java
@@ -797,6 +797,12 @@ public class SettingKey implements Serializable {
             .withDescription("Allow Int128, Int256, UInt256 and Decimal256 types")
             .build();
 
+    public static SettingKey client_name = SettingKey.builder()
+            .withName("client_name")
+            .withType(SettingType.UTF8)
+            .withDescription("identify who you are, it will record in system.query_log")
+            .build();
+
 
     public static SettingKey port = SettingKey.builder()
             .withName("port")

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickHouseDatabaseMetadataITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ClickHouseDatabaseMetadataITest.java
@@ -47,7 +47,7 @@ class ClickHouseDatabaseMetadataITest extends AbstractITest {
     void getURL() throws Exception {
         withNewConnection(connection -> {
             DatabaseMetaData dm = connection.getMetaData();
-            assertEquals(String.format(Locale.ROOT, "jdbc:clickhouse://%s:%s/default?query_timeout=0&connect_timeout=0&charset=UTF-8&tcp_keep_alive=false", CK_HOST, CK_PORT),
+            assertEquals(String.format(Locale.ROOT, "jdbc:clickhouse://%s:%s/default?query_timeout=0&connect_timeout=0&charset=UTF-8&client_name=ClickHouse client&tcp_keep_alive=false", CK_HOST, CK_PORT),
                     dm.getURL());
         });
     }

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/settings/ClickHouseConfigTest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/settings/ClickHouseConfigTest.java
@@ -38,7 +38,7 @@ class ClickHouseConfigTest {
         assertEquals(StandardCharsets.UTF_8, cfg.charset());
         assertFalse(cfg.tcpKeepAlive());
         assertEquals("default", cfg.database());
-        assertEquals("jdbc:clickhouse://127.0.0.1:9000/default?query_timeout=0&connect_timeout=0&charset=UTF-8&tcp_keep_alive=false",
+        assertEquals("jdbc:clickhouse://127.0.0.1:9000/default?query_timeout=0&connect_timeout=0&charset=UTF-8&client_name=ClickHouse client&tcp_keep_alive=false",
                 cfg.jdbcUrl());
     }
 
@@ -47,6 +47,7 @@ class ClickHouseConfigTest {
         ClickHouseConfig cfg = ClickHouseConfig.Builder.builder()
                 .withJdbcUrl("jdbc:clickhouse://1.2.3.4:8123/db2")
                 .charset("GBK")
+                .clientName("ck-test")
                 .withSetting(SettingKey.allow_distributed_ddl, true)
                 .build()
                 .withCredentials("user", "passWorD");
@@ -59,7 +60,7 @@ class ClickHouseConfigTest {
         assertEquals(Charset.forName("GBK"), cfg.charset());
         assertFalse(cfg.tcpKeepAlive());
         assertEquals("db2", cfg.database());
-        assertEquals("jdbc:clickhouse://1.2.3.4:8123/db2?query_timeout=0&connect_timeout=0&charset=GBK&tcp_keep_alive=false&allow_distributed_ddl=true",
+        assertEquals("jdbc:clickhouse://1.2.3.4:8123/db2?query_timeout=0&connect_timeout=0&charset=GBK&client_name=ck-test&tcp_keep_alive=false&allow_distributed_ddl=true",
                 cfg.jdbcUrl());
     }
 

--- a/examples/src/main/java/examples/SimpleQuery.java
+++ b/examples/src/main/java/examples/SimpleQuery.java
@@ -25,7 +25,7 @@ import java.sql.Statement;
 public class SimpleQuery {
 
     public static void main(String[] args) throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1:9000")) {
+        try (Connection connection = DriverManager.getConnection("jdbc:clickhouse://127.0.0.1:9000?client_name=ck-example")) {
             try (Statement stmt = connection.createStatement()) {
                 try (ResultSet rs = stmt.executeQuery(
                         "SELECT (number % 3 + 1) as n, sum(number) FROM numbers(10000000) GROUP BY n")) {


### PR DESCRIPTION
#361 
you can config your client name in jdbc url or datasource properties with client_name.
for example
Properties props = new Properties();
props.put("client_name", "ck-client");
DataSource singleDataSource = new BalancedClickhouseDataSource("jdbc:clickhouse://127.0.0.1:9000", props);