### PR TITLE
Return the name of the type instead of the name of the column

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseDatabaseMetadata.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseDatabaseMetadata.java
@@ -914,7 +914,7 @@ public final class ClickHouseDatabaseMetadata implements SQLDatabaseMetadata {
             //data type
             row.add(dataType.sqlTypeId());
             //type name
-            row.add(descTable.getString("name"));
+            row.add(dataType.name());
             // column size / precision
             row.add(dataType.getPrecision());
             //buffer length


### PR DESCRIPTION
getColumns returns wrong metadata because it was returning the name of the column instead of the name of the datatype