### PR TITLE
fix date value error when bigger than short

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/data/type/DataTypeDate.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/data/type/DataTypeDate.java
@@ -77,7 +77,7 @@ public class DataTypeDate implements IDataType<LocalDate, Date> {
     @Override
     public LocalDate deserializeBinary(BinaryDeserializer deserializer) throws IOException {
         short epochDay = deserializer.readShort();
-        return LocalDate.ofEpochDay(epochDay);
+        return LocalDate.ofEpochDay(epochDay & 0xFFFF);
     }
 
     @Override

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QuerySimpleTypeITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/QuerySimpleTypeITest.java
@@ -75,6 +75,18 @@ public class QuerySimpleTypeITest extends AbstractITest {
     }
 
     @Test
+    public void successfullyDateColumn() throws Exception {
+        withNewConnection(connect -> {
+            Statement statement = connect.createStatement();
+            ResultSet rs = statement.executeQuery("SELECT toDate('2105-12-30') AS value, toTypeName(value)");
+
+            assertTrue(rs.next());
+            assertEquals(Date.valueOf("2105-12-30"), rs.getDate(1));
+            assertEquals("Date", rs.getString(2));
+        });
+    }
+
+    @Test
     public void successfullyIntColumn() throws Exception {
         withStatement(statement -> {
             ResultSet rs = statement.executeQuery(


### PR DESCRIPTION
When date value is bigger than short range, the value will error. because clickhouse date is uint16