### PR TITLE
Improve ColumnWriteBuffer recycling

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedInsertStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHousePreparedInsertStatement.java
@@ -130,7 +130,7 @@ public class ClickHousePreparedInsertStatement extends AbstractPreparedStatement
         addParameters();
         int result = connection.sendInsertRequest(block);
         this.blockInit = false;
-        this.block.initWriteBuffer();
+        this.block.cleanup();
         return result;
     }
 
@@ -156,7 +156,7 @@ public class ClickHousePreparedInsertStatement extends AbstractPreparedStatement
         Arrays.fill(result, 1);
         clearBatch();
         this.blockInit = false;
-        this.block.initWriteBuffer();
+        this.block.cleanup();
         return result;
     }
 
@@ -166,7 +166,6 @@ public class ClickHousePreparedInsertStatement extends AbstractPreparedStatement
             // Empty insert when close.
             this.connection.sendInsertRequest(new Block());
             this.blockInit = false;
-            this.block.initWriteBuffer();
         }
         // clean up block on close
         this.block.cleanup();

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
@@ -86,6 +86,7 @@ public class ClickHouseStatement implements SQLStatement {
                 block.initWriteBuffer();
                 new ValuesNativeInputFormat(matcher.end() - 1, query).fill(block);
                 updateCount = connection.sendInsertRequest(block);
+                block.cleanup();
                 return updateCount;
             }
             updateCount = -1;


### PR DESCRIPTION
Return buffers to the pool after executing prepared INSERT statement, so they can be reused again even if statement is not closed