### PR TITLE
Further minimize buffer allocation in INSERT path. Remove one of writeBinary() overrides.

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/BuffedWriter.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/BuffedWriter.java
@@ -20,8 +20,6 @@ public interface BuffedWriter {
 
     void writeBinary(byte byt) throws IOException;
 
-    void writeBinary(byte[] bytes) throws IOException;
-
     void writeBinary(byte[] bytes, int offset, int length) throws IOException;
 
     void flushToTarget(boolean force) throws IOException;

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/ByteArrayWriter.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/ByteArrayWriter.java
@@ -43,11 +43,6 @@ public class ByteArrayWriter implements BuffedWriter {
     }
 
     @Override
-    public void writeBinary(byte[] bytes) throws IOException {
-        writeBinary(bytes, 0, bytes.length);
-    }
-
-    @Override
     public void writeBinary(byte[] bytes, int offset, int length) throws IOException {
 
         while (buffer.remaining() < length) {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/CompressedBuffedWriter.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/CompressedBuffedWriter.java
@@ -49,11 +49,6 @@ public class CompressedBuffedWriter implements BuffedWriter, BytesHelper {
     }
 
     @Override
-    public void writeBinary(byte[] bytes) throws IOException {
-        writeBinary(bytes, 0, bytes.length);
-    }
-
-    @Override
     public void writeBinary(byte[] bytes, int offset, int length) throws IOException {
         while (remaining() < length) {
             int num = remaining();

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/SocketBuffedWriter.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/buffer/SocketBuffedWriter.java
@@ -32,11 +32,6 @@ public class SocketBuffedWriter implements BuffedWriter {
     }
 
     @Override
-    public void writeBinary(byte[] bytes) throws IOException {
-        out.write(bytes);
-    }
-
-    @Override
     public void writeBinary(byte[] bytes, int offset, int length) throws IOException {
         out.write(bytes, offset, length);
     }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/data/ColumnWriterBuffer.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/data/ColumnWriterBuffer.java
@@ -18,37 +18,25 @@ import com.github.housepower.buffer.ByteArrayWriter;
 import com.github.housepower.serde.BinarySerializer;
 import com.github.housepower.settings.ClickHouseDefines;
 
-import static java.lang.Math.min;
-
 import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 public class ColumnWriterBuffer {
 
     private final ByteArrayWriter columnWriter;
 
-    public BinarySerializer column;
+    public final BinarySerializer column;
 
     public ColumnWriterBuffer() {
         this.columnWriter = new ByteArrayWriter(ClickHouseDefines.COLUMN_BUFFER_BYTES);
         this.column = new BinarySerializer(columnWriter, false);
     }
 
-    @SuppressWarnings("RedundantCast")
     public void writeTo(BinarySerializer serializer) throws IOException {
-        // add a temp buffer to reduce memory requirement in case of large remaining data in buffer
-        byte[] writeBuffer = new byte[4*1024];
         for (ByteBuffer buffer : columnWriter.getBufferList()) {
-            // upcast is necessary, see detail at:
-            // https://bitbucket.org/ijabz/jaudiotagger/issues/313/java-8-javalangnosuchmethoderror
-            ((Buffer) buffer).flip();
-            while (buffer.hasRemaining()) {
-                int remaining = buffer.remaining();
-                int thisLength = min(remaining, writeBuffer.length);
-                buffer.get(writeBuffer, 0, thisLength);
-                serializer.writeBytes(writeBuffer, 0, thisLength);
-            }
+            serializer.writeBytes(buffer.array(), buffer.arrayOffset(), buffer.position());
+            // put buffer into state matching original flip() + relative get() behaviour; likely unnecessary
+            buffer.limit(buffer.position());
         }
     }
 

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/serde/BinarySerializer.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/serde/BinarySerializer.java
@@ -111,7 +111,7 @@ public class BinarySerializer {
 
     public void writeBytesBinary(byte[] bs) throws IOException {
         writeVarInt(bs.length);
-        switcher.get().writeBinary(bs);
+        switcher.get().writeBinary(bs, 0, bs.length);
     }
 
     public void flushToTarget(boolean force) throws IOException {
@@ -153,7 +153,7 @@ public class BinarySerializer {
     }
 
     public void writeBytes(byte[] bytes) throws IOException {
-        switcher.get().writeBinary(bytes);
+        writeBytes(bytes, 0, bytes.length);
     }
     
     public void writeBytes(byte[] bytes, int offset, int length) throws IOException {


### PR DESCRIPTION
Instead of copying serialized column data from ByteBuffer via intermediate byte[], just write backing array directly. This somewhat couples ColumnWriterBuffer with ByteArrayWriter internals, however as the name implies ByteArrayWriter is expected to use heap buffers (and using direct buffers for block data wouldn't make much sense now anyway - I/O layer is operating on byte[], plus most JVMs impose limits on direct memory allocation).
ByteArrayWriter and CompressedBuffedWriter use fixed-size buffers internally and chunk bytes already.
SocketBuffedWriter may benefit from splitting large writes into smaller ones to minimize malloc/free in native code - but it shouldn't be worse than current situation (at least with compression) and likely to be dubious optimisation.