### PR TITLE
Support failover

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseConnection.java
@@ -74,6 +74,10 @@ public class ClickHouseConnection implements SQLConnection {
         return nativeCtx.clientCtx();
     }
 
+    public NativeContext nativeContext() {
+        return nativeCtx;
+    }
+
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
     }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseDriver.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickHouseDriver.java
@@ -57,7 +57,7 @@ public class ClickHouseDriver implements Driver {
             case SINGLE_CONNECTION:
             default:
                 return singleConnection(url, properties);
-        }ClickHouseConnection
+        }
     }
 
     ClickHouseConnection connect(String url, ClickHouseConfig cfg) throws SQLException {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickhouseJdbcUrlParser.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickhouseJdbcUrlParser.java
@@ -15,27 +15,70 @@
 package com.github.housepower.jdbc;
 
 import com.github.housepower.exception.InvalidValueException;
-import com.github.housepower.misc.Validate;
-import com.github.housepower.settings.SettingKey;
 import com.github.housepower.log.Logger;
 import com.github.housepower.log.LoggerFactory;
+import com.github.housepower.misc.Validate;
+import com.github.housepower.settings.SettingKey;
 
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.github.housepower.misc.StrUtil.isBlank;
+import static com.github.housepower.misc.StrUtil.isNotBlank;
 
 public class ClickhouseJdbcUrlParser {
     public static final String JDBC_PREFIX = "jdbc:";
     public static final String CLICKHOUSE_PREFIX = "clickhouse:";
     public static final String JDBC_CLICKHOUSE_PREFIX = JDBC_PREFIX + CLICKHOUSE_PREFIX;
 
+    public static final String HOST_DELIMITER = ",";
+
     public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
     public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^/:\\s]+)(:(?<port>\\d+))?");
 
+    private static final Pattern CONNECTION_STRING_PTRN = Pattern.compile("(?<scheme>[\\w\\+:%]+)\\s*" // scheme: required; alphanumeric, plus, colon or percent
+            + "(?://(?<hosts>[^/?#]*))?\\s*" // authority: optional; starts with "//" followed by any char except "/", "?" and "#"
+            + "(?:/(?!\\s*/)(?<database>[^?#]*))?" // path: optional; starts with "/" but not followed by "/", and then followed by by any char except "?" and "#"
+            + "(?:\\?(?!\\s*\\?)(?<queryParameters>[^#]*))?" // query: optional; starts with "?" but not followed by "?", and then followed by by any char except "#"
+            + "(?:\\s*#(?<fragment>.*))?"); // fragment: optional; starts with "#", and then followed by anything
+
     private static final Logger LOG = LoggerFactory.getLogger(ClickhouseJdbcUrlParser.class);
+
+    private final String baseConnectionString;
+    private String scheme;
+    private String hosts;
+    private String database;
+    private String queryParameters;
+
+    public ClickhouseJdbcUrlParser(String jdbcUrl) {
+        this.baseConnectionString = jdbcUrl;
+        parseConnectionString();
+    }
+
+    /**
+     * Static factory method for constructing instances of this class.
+     *
+     * @param connString The connection string to parse.
+     * @return an instance of {@link ClickhouseJdbcUrlParser}
+     */
+    public static ClickhouseJdbcUrlParser parseConnectionString(String connString) {
+        return new ClickhouseJdbcUrlParser(connString);
+    }
+
 
     public static Map<SettingKey, Serializable> parseJdbcUrl(String jdbcUrl) {
         try {
@@ -137,6 +180,23 @@ public class ClickhouseJdbcUrlParser {
         return parameters;
     }
 
+    public List<String> getSingleHostJdbcUrls() {
+        return Arrays.stream(hosts.split(HOST_DELIMITER))
+                .map(host -> {
+                    String url = scheme + "//" + host;
+
+                    if (isNotBlank(database)) {
+                        url += "/" + database;
+                    }
+
+                    if (isNotBlank(queryParameters)) {
+                        url += "?" + queryParameters;
+                    }
+
+                    return url;
+                }).collect(Collectors.toList());
+    }
+
     private static void parseSetting(Map<SettingKey, Serializable> settings, String name, String value) {
         SettingKey settingKey = SettingKey.definedSettingKeys().get(name.toLowerCase(Locale.ROOT));
         if (settingKey != null) {
@@ -144,5 +204,64 @@ public class ClickhouseJdbcUrlParser {
         } else {
             LOG.warn("ignore undefined setting: {}={}", name, value);
         }
+    }
+
+    /**
+     * Splits the connection string in its main sections.
+     */
+    private void parseConnectionString() {
+        Matcher matcher = CONNECTION_STRING_PTRN.matcher(this.baseConnectionString);
+        if (!matcher.matches()) {
+            throw new InvalidValueException("Connection is not support ");
+        }
+        this.scheme = decodeSkippingPlusSign(matcher.group("scheme"));
+        this.hosts = matcher.group("hosts"); // Don't decode just yet.
+        this.database = matcher.group("database") == null ? null : decode(matcher.group("database")).trim();
+        this.queryParameters = matcher.group("queryParameters"); // Don't decode just yet.
+    }
+
+    /**
+     * URL-decode the given string skipping all occurrences of the plus sign.
+     *
+     * @param text the string to decode
+     * @return the decoded string
+     */
+    private static String decodeSkippingPlusSign(String text) {
+        if (isBlank(text)) {
+            return text;
+        }
+        text = text.replace("+", "%2B"); // Percent encode for "+" is "%2B".
+        try {
+            return URLDecoder.decode(text, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            // Won't happen.
+        }
+        return "";
+    }
+
+    /**
+     * URL-decode the given string.
+     *
+     * @param text the string to decode
+     * @return the decoded string
+     */
+    private static String decode(String text) {
+        if (isBlank(text)) {
+            return text;
+        }
+        try {
+            return URLDecoder.decode(text, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            // Won't happen.
+        }
+        return "";
+    }
+
+    public List<String> getHosts() {
+        return Arrays.asList(this.hosts.split(HOST_DELIMITER));
+    }
+
+    public String getScheme() {
+        return this.scheme;
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ConnectionUrl.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ConnectionUrl.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.housepower.jdbc;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ConnectionUrl {
+    private final Type type;
+    private final List<String> singleConnectUrls;
+
+    /**
+     * The rules describing the number of hosts a database URL may contain.
+     */
+    public enum HostsCardinality {
+        SINGLE {
+            @Override
+            public boolean assertSize(int n) {
+                return n == 1;
+            }
+        },
+        MULTIPLE {
+            @Override
+            public boolean assertSize(int n) {
+                return n > 1;
+            }
+        },
+        ONE_OR_MORE {
+            @Override
+            public boolean assertSize(int n) {
+                return n >= 1;
+            }
+        };
+
+        public abstract boolean assertSize(int n);
+    }
+
+    /**
+     * The database URL type which is determined by the scheme section of the connection string.
+     */
+    public enum Type {
+        // Standard schemes:
+        SINGLE_CONNECTION("jdbc:clickhouse:", HostsCardinality.SINGLE), //
+        FAILOVER_CONNECTION("jdbc:clickhouse:", HostsCardinality.MULTIPLE);
+
+        private final String scheme;
+        private final HostsCardinality cardinality;
+
+        Type(String scheme, HostsCardinality cardinality) {
+            this.scheme = scheme;
+            this.cardinality = cardinality;
+        }
+
+        public String getScheme() {
+            return this.scheme;
+        }
+
+        public HostsCardinality getCardinality() {
+            return this.cardinality;
+        }
+
+        /**
+         * Returns the {@link Type} corresponding to the given scheme and number of hosts, if any.
+         * Calling this method with the argument n lower than 0 skips the hosts cardinality validation.
+         *
+         * @param scheme one of supported schemes
+         * @param n      the number of hosts in the database URL
+         * @return the {@link Type} corresponding to the given protocol and number of hosts
+         */
+        public static Type fromValue(String scheme, int n) {
+            for (Type t : values()) {
+                if (t.getScheme().equalsIgnoreCase(scheme) && (n < 0 || t.getCardinality().assertSize(n))) {
+                    return t;
+                }
+            }
+
+            return Type.SINGLE_CONNECTION;
+        }
+
+        public static Type getConnectionType(ClickhouseJdbcUrlParser parser) {
+            return fromValue(parser.getScheme(), parser.getHosts().size());
+        }
+    }
+
+    public ConnectionUrl(String connString) {
+        ClickhouseJdbcUrlParser parser = ClickhouseJdbcUrlParser.parseConnectionString(connString);
+
+        this.singleConnectUrls = parser.getSingleHostJdbcUrls();
+        this.type = Type.getConnectionType(parser);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public List<String> getSingleConnectUrls() {
+        return Collections.unmodifiableList(singleConnectUrls);
+    }
+
+}

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/FailoverConnectionProxy.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/FailoverConnectionProxy.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.housepower.jdbc;
+
+
+import com.github.housepower.client.NativeContext;
+import com.github.housepower.jdbc.statement.ClickHouseStatement;
+import com.github.housepower.log.Logger;
+import com.github.housepower.log.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+public class FailoverConnectionProxy extends MultiHostConnectionProxy {
+    private static final Logger LOG = LoggerFactory.getLogger(FailoverConnectionProxy.class);
+
+    private static final int NO_CONNECTION_INDEX = -1;
+
+    private int currentHostIndex = NO_CONNECTION_INDEX;
+
+    private final int retriesAllDown;
+
+    /**
+     * Proxy class to intercept and deal with errors that may occur in any object bound to the current connection.
+     * Additionally intercepts query executions and triggers an execution count on the outer class.
+     */
+    class FailoverJdbcInterfaceProxy extends JdbcInterfaceProxy {
+        FailoverJdbcInterfaceProxy(Object toInvokeOn, FailoverConnectionProxy failoverConnectionProxy) {
+            super(toInvokeOn, failoverConnectionProxy);
+        }
+
+        @SuppressWarnings("synthetic-access")
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            String methodName = method.getName();
+
+            boolean isExecute = methodName.startsWith("execute");
+            int tryIndex = currentHostIndex;
+            Throwable t;
+
+            do {
+                tryIndex = currentHostIndex;
+                try {
+                    return super.invoke(proxy, method, args);
+                } catch (Throwable e) {
+                    t = e;
+
+                    for (Class<?> in : proxy.getClass().getInterfaces()) {
+                        if (Statement.class.isAssignableFrom(in)) {
+                            super.invoke(proxy, ClickHouseStatement.class.getMethod("resetConnect", ClickHouseConnection.class, NativeContext.class), new Object[]{multiHostConnectionProxy.currentConnection, multiHostConnectionProxy.currentConnection.nativeContext()});
+                            break;
+                        }
+                    }
+                }
+            }
+            while (!multiHostConnectionProxy.isClosed && isExecute && tryIndex != urlsList.size() - 1);
+
+            throw t;
+        }
+    }
+
+    @Override
+    boolean shouldExceptionTriggerConnectionSwitch(Throwable t) {
+        return t instanceof SQLException && this.retriesAllDown - 1 != this.currentHostIndex;
+    }
+
+    /*
+     * Local implementation for the new connection picker.
+     */
+    @Override
+    synchronized void pickNewConnection() throws SQLException {
+        if (this.isClosed) {
+            return;
+        }
+
+        failOver();
+    }
+
+    @Override
+    void doClose() throws SQLException {
+        this.currentConnection.close();
+    }
+
+    @Override
+    void doAbort(Executor executor) throws SQLException {
+        this.currentConnection.abort(executor);
+    }
+
+    @Override
+    Object invokeMore(Object proxy, Method method, Object[] args) throws Throwable {
+        Object result = null;
+
+        try {
+            result = method.invoke(this.currentConnection, args);
+            result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
+        } catch (InvocationTargetException e) {
+            dealWithInvocationException(e);
+        }
+
+        return result;
+    }
+
+    /**
+     * Initiates a default failover procedure starting at the current connection host index.
+     *
+     * @throws SQLException if an error occurs
+     */
+    private synchronized void failOver() throws SQLException {
+        failOver(this.currentHostIndex);
+    }
+
+    /**
+     * Initiates a default failover procedure starting at the given host index.
+     * This process tries to connect, sequentially, to the next host in the list. The primary host may or may not be excluded from the connection attempts.
+     *
+     * @param failedHostIdx The host index where to start from. First connection attempt will be the next one.
+     * @throws SQLException if an error occurs
+     */
+    private synchronized void failOver(int failedHostIdx) throws SQLException {
+
+        int nextHostIndex = nextHost(failedHostIdx);
+        int firstHostIndexTried = nextHostIndex;
+
+        SQLException lastExceptionCaught = null;
+        int attempts = 0;
+        boolean gotConnection = false;
+
+        do {
+            try {
+                connectTo(nextHostIndex);
+                gotConnection = true;
+            } catch (SQLException e) {
+                lastExceptionCaught = e;
+
+                if (shouldExceptionTriggerConnectionSwitch(e)) {
+                    int newNextHostIndex = nextHost(nextHostIndex);
+
+                    if (newNextHostIndex == firstHostIndexTried && newNextHostIndex == (newNextHostIndex = nextHost(nextHostIndex))) { // Full turn
+                        attempts++;
+
+                        try {
+                            Thread.sleep(250);
+                        } catch (InterruptedException ignore) {
+                        }
+                    }
+
+                    nextHostIndex = newNextHostIndex;
+
+                } else {
+                    throw e;
+                }
+            }
+        } while (attempts < this.retriesAllDown && !gotConnection);
+
+        if (!gotConnection) {
+            throw lastExceptionCaught;
+        }
+    }
+
+    private int nextHost(int currHostIdx) {
+        return (currHostIdx + 1) % this.urlsList.size();
+    }
+
+    /**
+     * Connects this dynamic failover connection proxy to the host pointed out by the given host index.
+     *
+     * @param hostIndex The host index in the global hosts list.
+     * @throws SQLException if an error occurs
+     */
+    private synchronized void connectTo(int hostIndex) throws SQLException {
+        try {
+            switchCurrentConnectionTo(hostIndex, createConnectionForHostIndex(hostIndex));
+        } catch (SQLException e) {
+            if (this.currentConnection != null) {
+                String msg = "Connection to " + " url '" +
+                        this.urlsList.get(hostIndex) + "' failed";
+                LOG.error(msg);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Replaces the previous underlying connection by the connection given. State from previous connection, if any, is synchronized with the new one.
+     *
+     * @param hostIndex  The host index in the global hosts list that matches the given connection.
+     * @param connection The connection instance to switch to.
+     */
+    private synchronized void switchCurrentConnectionTo(int hostIndex, ClickHouseConnection connection) {
+        invalidateCurrentConnection();
+        this.currentConnection = connection;
+        this.currentHostIndex = hostIndex;
+    }
+
+    /**
+     * Creates a new connection instance for host pointed out by the given host index.
+     *
+     * @param hostIndex The host index in the global hosts list.
+     * @return The new connection instance.
+     * @throws SQLException if an error occurs
+     */
+    synchronized ClickHouseConnection createConnectionForHostIndex(int hostIndex) throws SQLException {
+        return createConnectionForHost(this.urlsList.get(hostIndex));
+    }
+
+    public static Connection createProxyInstance(List<String> urls, Properties properties) throws SQLException {
+        FailoverConnectionProxy connProxy = new FailoverConnectionProxy(urls, properties);
+
+        return (Connection) java.lang.reflect.Proxy.newProxyInstance(ClickHouseConnection.class.getClassLoader(), new Class<?>[]{Connection.class},
+                connProxy);
+    }
+
+    /**
+     * Instantiates a new FailoverConnectionProxy for the given list of hosts and connection properties.
+     *
+     * @param urls       The connection URL that initialized this multi-host connection.
+     * @param properties The connection properties.
+     * @throws SQLException if an error occurs
+     */
+    private FailoverConnectionProxy(List<String> urls, Properties properties) throws SQLException {
+        super(urls, properties);
+        this.retriesAllDown = urls.size();
+        pickNewConnection();
+    }
+
+    /**
+     * Gets locally bound instances of FailoverJdbcInterfaceProxy.
+     */
+    @Override
+    JdbcInterfaceProxy getNewJdbcInterfaceProxy(Object toProxy) {
+        return new FailoverJdbcInterfaceProxy(toProxy, this);
+    }
+
+}

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/MultiHostConnectionProxy.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/MultiHostConnectionProxy.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.housepower.jdbc;
+
+
+import com.github.housepower.log.Logger;
+import com.github.housepower.log.LoggerFactory;
+import com.github.housepower.settings.ClickHouseConfig;
+import com.github.housepower.util.Util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * An abstract class that processes generic multi-host configurations. This class has to be sub-classed by specific multi-host implementations, such as
+ * load-balancing and failover.
+ */
+public abstract class MultiHostConnectionProxy implements InvocationHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(MultiHostConnectionProxy.class);
+
+    private static final String METHOD_EQUALS = "equals";
+    private static final String METHOD_CLOSE = "close";
+    private static final String METHOD_ABORT = "abort";
+    private static final String METHOD_IS_CLOSED = "isClosed";
+
+    List<String> urlsList;
+    boolean isClosed = false;
+
+    protected Properties properties;
+
+    ClickHouseConnection currentConnection = null;
+
+    // Keep track of the last exception processed in 'dealWithInvocationException()' in order to avoid creating connections repeatedly from each time the same
+    // exception is caught in every proxy instance belonging to the same call stack.
+    protected Throwable lastExceptionDealtWith = null;
+
+    /**
+     * Proxy class to intercept and deal with errors that may occur in any object bound to the current connection.
+     */
+    class JdbcInterfaceProxy implements InvocationHandler {
+        Object invokeOn;
+        MultiHostConnectionProxy multiHostConnectionProxy;
+
+        JdbcInterfaceProxy(Object toInvokeOn, MultiHostConnectionProxy multiHostConnectionProxy) {
+            this.invokeOn = toInvokeOn;
+            this.multiHostConnectionProxy = multiHostConnectionProxy;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (METHOD_EQUALS.equals(method.getName())) {
+                // Let args[0] "unwrap" to its InvocationHandler if it is a proxy.
+                return args[0].equals(this);
+            }
+
+            synchronized (MultiHostConnectionProxy.this) {
+                Object result = null;
+
+                try {
+                    result = method.invoke(this.invokeOn, args);
+                    result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
+                } catch (InvocationTargetException e) {
+                    dealWithInvocationException(e);
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /**
+     * If the given return type is or implements a JDBC interface, proxies the given object so that we can catch SQL errors and fire a connection switch.
+     *
+     * @param returnType The type the object instance to proxy is supposed to be.
+     * @param toProxy    The object instance to proxy.
+     * @return The proxied object or the original one if it does not implement a JDBC interface.
+     */
+    Object proxyIfReturnTypeIsJdbcInterface(Class<?> returnType, Object toProxy) {
+        if (toProxy != null) {
+            if (Util.isJdbcInterface(returnType)) {
+                Class<?> toProxyClass = toProxy.getClass();
+                return Proxy.newProxyInstance(toProxyClass.getClassLoader(), Util.getImplementedInterfaces(toProxyClass), getNewJdbcInterfaceProxy(toProxy));
+            }
+        }
+        return toProxy;
+    }
+
+    /**
+     * Instantiates a new JdbcInterfaceProxy for the given object. Subclasses can override this to return instances of JdbcInterfaceProxy subclasses.
+     *
+     * @param toProxy The object instance to be proxied.
+     * @return The new InvocationHandler instance.
+     */
+    InvocationHandler getNewJdbcInterfaceProxy(Object toProxy) {
+        return new JdbcInterfaceProxy(toProxy, this);
+    }
+
+    /**
+     * Deals with InvocationException from proxied objects.
+     *
+     * @param e The Exception instance to check.
+     * @throws SQLException              if an error occurs
+     * @throws Throwable                 if an error occurs
+     * @throws InvocationTargetException if an error occurs
+     */
+    void dealWithInvocationException(InvocationTargetException e) throws SQLException, Throwable, InvocationTargetException {
+        Throwable t = e.getTargetException();
+
+        if (t != null) {
+            if (this.lastExceptionDealtWith != t && shouldExceptionTriggerConnectionSwitch(t)) {
+                invalidateCurrentConnection();
+                pickNewConnection();
+                this.lastExceptionDealtWith = t;
+            }
+            throw t;
+        }
+        throw e;
+    }
+
+    /**
+     * Checks if the given throwable should trigger a connection switch.
+     *
+     * @param t The Throwable instance to analyze.
+     * @return true if the given throwable should trigger a connection switch
+     */
+    abstract boolean shouldExceptionTriggerConnectionSwitch(Throwable t);
+
+    /**
+     * Invalidates the current connection.
+     *
+     */
+    synchronized void invalidateCurrentConnection() {
+        invalidateConnection(this.currentConnection);
+    }
+
+    /**
+     * Invalidates the specified connection by closing it.
+     *
+     * @param conn The connection instance to invalidate.
+     */
+    synchronized void invalidateConnection(ClickHouseConnection conn) {
+        try {
+            if (conn != null && !conn.isClosed()) {
+                conn.close();
+            }
+        } catch (SQLException ignore) {
+            // swallow this exception, current connection should be useless anyway.
+        }
+    }
+
+    /**
+     * Picks the "best" connection to use from now on. Each subclass needs to implement its connection switch strategy on it.
+     *
+     * @throws SQLException if an error occurs
+     */
+    abstract void pickNewConnection() throws SQLException;
+
+    /**
+     * Proxies method invocation on the java.sql.Connection interface, trapping multi-host specific methods and generic methods.
+     * Subclasses have to override this to complete the method invocation process, deal with exceptions and decide when to switch connection.
+     * To avoid unnecessary additional exception handling overriders should consult #canDealWith(Method) before chaining here.
+     *
+     * @param proxy  proxy object
+     * @param method method to invoke
+     * @param args   method parameters
+     * @return method result
+     * @throws Throwable if an error occurs
+     */
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String methodName = method.getName();
+
+        if (METHOD_EQUALS.equals(methodName)) {
+            // Let args[0] "unwrap" to its InvocationHandler if it is a proxy.
+            return args[0].equals(this);
+        }
+
+        // Execute remaining ubiquitous methods right away.
+        if (method.getDeclaringClass().equals(Object.class)) {
+            return method.invoke(this, args);
+        }
+
+        synchronized (this) {
+            if (METHOD_CLOSE.equals(methodName)) {
+                doClose();
+                this.isClosed = true;
+                return null;
+            }
+
+            if (METHOD_ABORT.equals(methodName) && args.length == 1) { // TODO
+                this.isClosed = true;
+                doAbort((Executor) args[0]);
+                return null;
+            }
+
+            if (METHOD_IS_CLOSED.equals(methodName)) {
+                return this.isClosed;
+            }
+
+            try {
+                return invokeMore(proxy, method, args);
+            } catch (InvocationTargetException e) {
+                throw e.getCause() != null ? e.getCause() : e;
+            } catch (Exception e) {
+                // Check if the captured exception must be wrapped by an unchecked exception.
+                Class<?>[] declaredException = method.getExceptionTypes();
+                for (Class<?> declEx : declaredException) {
+                    if (declEx.isAssignableFrom(e.getClass())) {
+                        throw e;
+                    }
+                }
+                throw new IllegalStateException(e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Executes a close() invocation;
+     *
+     * @throws SQLException if an error occurs
+     */
+    abstract void doClose() throws SQLException;
+
+    /**
+     * Executes a abort() invocation;
+     *
+     * @param executor executor
+     * @throws SQLException if an error occurs
+     */
+    abstract void doAbort(Executor executor) throws SQLException;
+
+    /**
+     * Continuation of the method invocation process, to be implemented within each subclass.
+     *
+     * @param proxy  proxy object
+     * @param method method to invoke
+     * @param args   method parameters
+     * @return method result
+     * @throws Throwable if an error occurs
+     */
+    abstract Object invokeMore(Object proxy, Method method, Object[] args) throws Throwable;
+
+
+    /**
+     * Constructs a MultiHostConnectionProxy instance for the given connection URL.
+     *
+     * @param urls       The connection URL that initialized this multi-host connection.
+     * @param properties The connection properties.
+     */
+    MultiHostConnectionProxy(List<String> urls, Properties properties) {
+        initializeHostsSpecs(urls, properties);
+    }
+
+    /**
+     * Initializes the hosts lists and makes a "clean" local copy of the given connection properties so that it can be later used to create standard
+     * connections.
+     *
+     * @param urls       The connection URL that initialized this multi-host connection.
+     * @param properties The connection properties.
+     */
+    void initializeHostsSpecs(List<String> urls, Properties properties) {
+        this.properties = properties;
+        this.urlsList = urls;
+    }
+
+    /**
+     * Creates a new physical connection for the given
+     *
+     * @param url The url info instance.
+     * @return The new Connection instance.
+     * @throws SQLException if an error occurs
+     */
+    synchronized ClickHouseConnection createConnectionForHost(String url) throws SQLException {
+        LOG.debug("Create connect.Url is {}", url);
+        ClickHouseConfig cfg = ClickHouseConfig.Builder.builder()
+                .withJdbcUrl(url)
+                .withProperties(this.properties)
+                .build();
+        return ClickHouseConnection.createClickHouseConnection(cfg.withJdbcUrl(url));
+    }
+
+}

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/statement/ClickHouseStatement.java
@@ -46,8 +46,8 @@ public class ClickHouseStatement implements SQLStatement {
 
     private ResultSet lastResultSet;
     protected Block block;
-    protected final ClickHouseConnection connection;
-    protected final NativeContext nativeContext;
+    protected volatile ClickHouseConnection connection;
+    protected volatile NativeContext nativeContext;
 
     private ClickHouseConfig cfg;
     private long maxRows;
@@ -259,5 +259,10 @@ public class ClickHouseStatement implements SQLStatement {
             db = "system";
             table = upperSQL.contains("TABLES") ? "tables" : "databases";
         }
+    }
+
+    public void resetConnect(ClickHouseConnection connection, NativeContext nativeContext) {
+        this.connection = connection;
+        this.nativeContext = nativeContext;
     }
 }

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/util/Util.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/util/Util.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.housepower.util;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class Util {
+    /** Cache for the JDBC interfaces already verified */
+    private static final ConcurrentMap<Class<?>, Boolean> isJdbcInterfaceCache = new ConcurrentHashMap<>();
+
+    /**
+     * Recursively checks for interfaces on the given class to determine if it implements a java.sql, javax.sql or com.github.housepower.jdbc interface.
+     *
+     * @param clazz
+     *            The class to investigate.
+     * @return boolean
+     */
+    public static boolean isJdbcInterface(Class<?> clazz) {
+        if (Util.isJdbcInterfaceCache.containsKey(clazz)) {
+            return (Util.isJdbcInterfaceCache.get(clazz));
+        }
+
+        if (clazz.isInterface()) {
+            try {
+                if (isJdbcPackage(clazz.getPackage().getName())) {
+                    Util.isJdbcInterfaceCache.putIfAbsent(clazz, true);
+                    return true;
+                }
+            } catch (Exception ex) {
+                /*
+                 * We may experience a NPE from getPackage() returning null, or class-loading facilities.
+                 * This happens when this class is instrumented to implement runtime-generated interfaces.
+                 */
+            }
+        }
+
+        for (Class<?> iface : clazz.getInterfaces()) {
+            if (isJdbcInterface(iface)) {
+                Util.isJdbcInterfaceCache.putIfAbsent(clazz, true);
+                return true;
+            }
+        }
+
+        if (clazz.getSuperclass() != null && isJdbcInterface(clazz.getSuperclass())) {
+            Util.isJdbcInterfaceCache.putIfAbsent(clazz, true);
+            return true;
+        }
+
+        Util.isJdbcInterfaceCache.putIfAbsent(clazz, false);
+        return false;
+    }
+
+    /**
+     * Check if the package name is a known JDBC package.
+     *
+     * @param packageName
+     *            The package name to check.
+     * @return boolean
+     */
+    public static boolean isJdbcPackage(String packageName) {
+        return packageName != null
+                && (packageName.startsWith("java.sql") || packageName.startsWith("javax.sql") || packageName.startsWith("com.github.housepower.jdbc"));
+    }
+
+    /** Cache for the implemented interfaces searched. */
+    private static final ConcurrentMap<Class<?>, Class<?>[]> implementedInterfacesCache = new ConcurrentHashMap<>();
+
+
+    /**
+     * Retrieves a list with all interfaces implemented by the given class. If possible gets this information from a cache instead of navigating through the
+     * object hierarchy. Results are stored in a cache for future reference.
+     *
+     * @param clazz
+     *            The class from which the interface list will be retrieved.
+     * @return
+     *         An array with all the interfaces for the given class.
+     */
+    public static Class<?>[] getImplementedInterfaces(Class<?> clazz) {
+        Class<?>[] implementedInterfaces = Util.implementedInterfacesCache.get(clazz);
+        if (implementedInterfaces != null) {
+            return implementedInterfaces;
+        }
+
+        Set<Class<?>> interfaces = new LinkedHashSet<>();
+        Class<?> superClass = clazz;
+        do {
+            Collections.addAll(interfaces, superClass.getInterfaces());
+        } while ((superClass = superClass.getSuperclass()) != null);
+
+        implementedInterfaces = interfaces.toArray(new Class<?>[interfaces.size()]);
+        Class<?>[] oldValue = Util.implementedInterfacesCache.putIfAbsent(clazz, implementedInterfaces);
+        if (oldValue != null) {
+            implementedInterfaces = oldValue;
+        }
+
+        return implementedInterfaces;
+    }
+}

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.housepower.jdbc;
+
+import com.github.housepower.log.Logger;
+import com.github.housepower.log.LoggerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FailoverClickhouseConnectionITest extends AbstractITest {
+    private static final Logger LOG = LoggerFactory.getLogger(FailoverClickhouseConnectionITest.class);
+
+    protected static int HA_PORT;
+
+    @Container
+    public static ClickHouseContainer containerHA = (ClickHouseContainer) new ClickHouseContainer(CLICKHOUSE_IMAGE)
+            .withEnv("CLICKHOUSE_USER", CLICKHOUSE_USER)
+            .withEnv("CLICKHOUSE_PASSWORD", CLICKHOUSE_PASSWORD)
+            .withEnv("CLICKHOUSE_DB", CLICKHOUSE_DB);
+
+
+    @BeforeEach
+    public void reset() throws SQLException {
+        resetDriverManager();
+        container.start();
+        containerHA.start();
+
+        CK_PORT = container.getMappedPort(ClickHouseContainer.NATIVE_PORT);
+        HA_PORT = containerHA.getMappedPort(ClickHouseContainer.NATIVE_PORT);
+        LOG.info("Port1 {}, Port2 {}", CK_PORT, HA_PORT);
+    }
+
+    @Test
+    public void testClickhouseDownBeforeConnect() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        container.stop();
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            withStatement(connection, stmt -> {
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforeStatement() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            container.stop();
+            withStatement(connection, stmt -> {
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforePrepareStatement() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            container.stop();
+            withPreparedStatement(connection, "select count() from system.tables", stmt -> {
+                ResultSet rs = stmt.executeQuery();
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforeExecute() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            withStatement(connection, stmt -> {
+                container.stop();
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforeAndAfterConnect() {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        Exception ex = null;
+        container.stop();
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default?query_id=xxx", haHost))
+        ) {
+            containerHA.stop();
+            withStatement(connection, stmt -> {
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        } catch (Exception e) {
+            ex = e;
+        }
+
+        assertNotNull(ex);
+    }
+}


### PR DESCRIPTION
Native Jdbc supports failover like
`jdbc:clickhouse://host1:port1,host2:port2/database`
second host will work  after first host is down