### PR TITLE
Extend JDBC URL pattern to support failover

### DIFF
--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/client/NativeClient.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/client/NativeClient.java
@@ -45,8 +45,12 @@ public class NativeClient {
     private static final Logger LOG = LoggerFactory.getLogger(NativeClient.class);
 
     public static NativeClient connect(ClickHouseConfig configure) throws SQLException {
+        return connect(configure.host(), configure.port(), configure);
+    }
+
+    public static NativeClient connect(String host, int port, ClickHouseConfig configure) throws SQLException {
         try {
-            SocketAddress endpoint = new InetSocketAddress(configure.host(), configure.port());
+            SocketAddress endpoint = new InetSocketAddress(host, port);
             // TODO support proxy
             Socket socket = new Socket();
             socket.setTcpNoDelay(true);

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickhouseJdbcUrlParser.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/jdbc/ClickhouseJdbcUrlParser.java
@@ -15,15 +15,17 @@
 package com.github.housepower.jdbc;
 
 import com.github.housepower.exception.InvalidValueException;
-import com.github.housepower.misc.Validate;
-import com.github.housepower.settings.SettingKey;
 import com.github.housepower.log.Logger;
 import com.github.housepower.log.LoggerFactory;
+import com.github.housepower.misc.Validate;
+import com.github.housepower.settings.SettingKey;
 
 import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,27 +34,45 @@ public class ClickhouseJdbcUrlParser {
     public static final String CLICKHOUSE_PREFIX = "clickhouse:";
     public static final String JDBC_CLICKHOUSE_PREFIX = JDBC_PREFIX + CLICKHOUSE_PREFIX;
 
-    public static final Pattern DB_PATH_PATTERN = Pattern.compile("/([a-zA-Z0-9_]+)");
-    public static final Pattern HOST_PORT_PATH_PATTERN = Pattern.compile("//(?<host>[^/:\\s]+)(:(?<port>\\d+))?");
+    public static final String HOST_DELIMITER = ",";
+    public static final String PORT_DELIMITER = ":";
+
+    public static final Pattern CONNECTION_PATTERN = Pattern.compile("//(?<hosts>[^/?\\s]+)(?:/(?<database>([a-zA-Z0-9_]+)))?(?:\\?(?<query>.*))?");
 
     private static final Logger LOG = LoggerFactory.getLogger(ClickhouseJdbcUrlParser.class);
 
     public static Map<SettingKey, Serializable> parseJdbcUrl(String jdbcUrl) {
-        try {
-            URI uri = new URI(jdbcUrl.substring(JDBC_PREFIX.length()));
-            String host = parseHost(jdbcUrl);
-            Integer port = parsePort(jdbcUrl);
-            String database = parseDatabase(jdbcUrl);
-            Map<SettingKey, Serializable> settings = new HashMap<>();
-            settings.put(SettingKey.host, host);
-            settings.put(SettingKey.port, port);
-            settings.put(SettingKey.database, database);
-            settings.putAll(extractQueryParameters(uri.getQuery()));
-
-            return settings;
-        } catch (URISyntaxException ex) {
-            throw new InvalidValueException(ex);
+        String uri = jdbcUrl.substring(JDBC_CLICKHOUSE_PREFIX.length());
+        Matcher matcher = CONNECTION_PATTERN.matcher(uri);
+        if (!matcher.matches()) {
+            throw new InvalidValueException("Connection is not support");
         }
+
+        Map<SettingKey, Serializable> settings = new HashMap<>();
+
+        String hosts = matcher.group("hosts");
+        String database = matcher.group("database");
+        String query = matcher.group("query");
+
+        if (hosts.contains(HOST_DELIMITER)) { // multi-host
+            settings.put(SettingKey.host, hosts);
+        } else { // standard-host
+            String[] hostAndPort = hosts.split(PORT_DELIMITER, 2);
+
+            settings.put(SettingKey.host, hostAndPort[0]);
+
+            if (hostAndPort.length == 2) {
+                if (Integer.parseInt(hostAndPort[1]) == 8123) {
+                    LOG.warn("8123 is default HTTP port, you may connect with error protocol!");
+                }
+                settings.put(SettingKey.port, Integer.parseInt(hostAndPort[1]));
+            }
+        }
+
+        settings.put(SettingKey.database, database);
+        settings.putAll(extractQueryParameters(query));
+
+        return settings;
     }
 
     public static Map<SettingKey, Serializable> parseProperties(Properties properties) {
@@ -65,59 +85,6 @@ public class ClickhouseJdbcUrlParser {
         }
 
         return settings;
-    }
-
-    private static String parseDatabase(String jdbcUrl) throws URISyntaxException {
-        URI uri = new URI(jdbcUrl.substring(JDBC_PREFIX.length()));
-        String database = uri.getPath();
-        if (database != null && !database.isEmpty()) {
-            Matcher m = DB_PATH_PATTERN.matcher(database);
-            if (m.matches()) {
-                database = m.group(1);
-            } else {
-                throw new URISyntaxException("wrong database name path: '" + database + "'", jdbcUrl);
-            }
-        }
-        if (database != null && database.isEmpty()) {
-            database = "default";
-        }
-        return database;
-    }
-
-    private static String parseHost(String jdbcUrl) throws URISyntaxException {
-        String uriStr = jdbcUrl.substring(JDBC_PREFIX.length());
-        URI uri = new URI(uriStr);
-        String host = uri.getHost();
-        if (host == null || host.isEmpty()) {
-            Matcher m = HOST_PORT_PATH_PATTERN.matcher(uriStr);
-            if (m.find()) {
-                host = m.group("host");
-            } else {
-                throw new URISyntaxException("No valid host was found", jdbcUrl);
-            }
-        }
-        return host;
-    }
-
-    private static int parsePort(String jdbcUrl) {
-        String uriStr = jdbcUrl.substring(JDBC_PREFIX.length());
-        URI uri;
-        try {
-            uri = new URI(uriStr);
-        } catch (Exception ex) {
-            throw new InvalidValueException(ex);
-        }
-        int port = uri.getPort();
-        if (port <= -1) {
-            Matcher m = HOST_PORT_PATH_PATTERN.matcher(uriStr);
-            if (m.find() && m.group("port") != null) {
-                port = Integer.parseInt(m.group("port"));
-            }
-        }
-        if (port == 8123) {
-            LOG.warn("8123 is default HTTP port, you may connect with error protocol!");
-        }
-        return port;
     }
 
     public static Map<SettingKey, Serializable> extractQueryParameters(String queryParameters) {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/settings/ClickHouseConfig.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/settings/ClickHouseConfig.java
@@ -22,15 +22,21 @@ import javax.annotation.concurrent.Immutable;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.github.housepower.jdbc.ClickhouseJdbcUrlParser.HOST_DELIMITER;
+
 @Immutable
 public class ClickHouseConfig implements Serializable {
 
+
     private final String host;
+    private final List<String> hosts;
     private final int port;
     private final String database;
     private final String user;
@@ -46,6 +52,7 @@ public class ClickHouseConfig implements Serializable {
                              Duration queryTimeout, Duration connectTimeout, boolean tcpKeepAlive,
                              String charset, String clientName, Map<SettingKey, Serializable> settings) {
         this.host = host;
+        this.hosts = Arrays.asList(host.split(HOST_DELIMITER));
         this.port = port;
         this.database = database;
         this.user = user;
@@ -60,6 +67,10 @@ public class ClickHouseConfig implements Serializable {
 
     public String host() {
         return this.host;
+    }
+
+    public List<String> hosts() {
+        return this.hosts;
     }
 
     public int port() {

--- a/clickhouse-native-jdbc/src/main/java/com/github/housepower/settings/ClickHouseConfig.java
+++ b/clickhouse-native-jdbc/src/main/java/com/github/housepower/settings/ClickHouseConfig.java
@@ -107,7 +107,13 @@ public class ClickHouseConfig implements Serializable {
 
     public String jdbcUrl() {
         StringBuilder builder = new StringBuilder(ClickhouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX)
-                .append("//").append(host).append(":").append(port).append("/").append(database)
+                .append("//").append(host);
+
+        if (hosts.size() == 1) {
+            builder.append(":").append(port);
+        }
+
+        builder.append("/").append(database)
                 .append("?").append(SettingKey.query_timeout.name()).append("=").append(queryTimeout.getSeconds())
                 .append("&").append(SettingKey.connect_timeout.name()).append("=").append(connectTimeout.getSeconds())
                 .append("&").append(SettingKey.charset.name()).append("=").append(charset)

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/ConnectionParamITest.java
@@ -14,6 +14,7 @@
 
 package com.github.housepower.jdbc;
 
+import com.github.housepower.exception.InvalidValueException;
 import com.github.housepower.settings.ClickHouseConfig;
 import com.github.housepower.settings.SettingKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -113,6 +114,36 @@ public class ConnectionParamITest extends AbstractITest {
         assertEquals("system", config.database());
         assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
         assertEquals(Duration.ofSeconds(50), config.connectTimeout());
+    }
+
+    @Test
+    public void successfullyFailoverHostNameWithCustomPort() {
+        String url = "jdbc:clickhouse://my_clickhouse_sever_host_name1:1940,my_clickhouse_sever_host_name2:1941/system?min_insert_block_size_rows=1000&connect_timeout=50";
+        ClickHouseConfig config = ClickHouseConfig.Builder.builder().withJdbcUrl(url).build();
+        assertEquals("my_clickhouse_sever_host_name1:1940,my_clickhouse_sever_host_name2:1941", config.host());
+        assertEquals(2, config.hosts().size());
+        assertEquals(9000, config.port());
+        assertEquals("system", config.database());
+        assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
+        assertEquals(Duration.ofSeconds(50), config.connectTimeout());
+    }
+
+    @Test
+    public void successfullyFailoverHostNameWithDefaultPort() {
+        String url = "jdbc:clickhouse://my_clickhouse_sever_host_name1,my_clickhouse_sever_host_name2/system?min_insert_block_size_rows=1000&connect_timeout=50";
+        ClickHouseConfig config = ClickHouseConfig.Builder.builder().withJdbcUrl(url).build();
+        assertEquals("my_clickhouse_sever_host_name1,my_clickhouse_sever_host_name2", config.host());
+        assertEquals(2, config.hosts().size());
+        assertEquals(9000, config.port());
+        assertEquals("system", config.database());
+        assertEquals(1000L, config.settings().get(SettingKey.min_insert_block_size_rows));
+        assertEquals(Duration.ofSeconds(50), config.connectTimeout());
+    }
+
+    @Test
+    public void successWrongUrlParser() {
+        String url = "jdbc:clickhouse://127.0.0. 1/system?min_insert_block_size_rows=1000&connect_timeout=50";
+        assertThrows(InvalidValueException.class, () -> ClickHouseConfig.Builder.builder().withJdbcUrl(url).build());
     }
 
     @Test

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FailoverClickhouseConnectionITest extends AbstractITest {
     private static final Logger LOG = LoggerFactory.getLogger(FailoverClickhouseConnectionITest.class);
 
+    protected static String HA_HOST;
     protected static int HA_PORT;
 
     @Container
@@ -49,13 +50,14 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
         containerHA.start();
 
         CK_PORT = container.getMappedPort(ClickHouseContainer.NATIVE_PORT);
+        HA_HOST = containerHA.getHost();
         HA_PORT = containerHA.getMappedPort(ClickHouseContainer.NATIVE_PORT);
         LOG.info("Port1 {}, Port2 {}", CK_PORT, HA_PORT);
     }
 
     @Test
     public void testClickhouseDownBeforeConnect() throws Exception {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, HA_HOST, HA_PORT);
 
         container.stop();
         try (Connection connection = DriverManager
@@ -73,7 +75,7 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
 
     @Test
     public void testClickhouseDownBeforeStatement() throws Exception {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, HA_HOST, HA_PORT);
 
         try (Connection connection = DriverManager
                 .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
@@ -91,7 +93,7 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
 
     @Test
     public void testClickhouseDownBeforePrepareStatement() throws Exception {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, HA_HOST, HA_PORT);
 
         try (Connection connection = DriverManager
                 .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
@@ -109,7 +111,7 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
 
     @Test
     public void testClickhouseDownBeforeExecute() throws Exception {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, HA_HOST, HA_PORT);
 
         try (Connection connection = DriverManager
                 .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
@@ -127,7 +129,7 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
 
     @Test
     public void testClickhouseDownBeforeAndAfterConnect() {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, HA_HOST, HA_PORT);
 
         Exception ex = null;
         container.stop();
@@ -151,7 +153,7 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
 
     @Test
     public void testClickhouseAllDownBeforeConnect() throws Exception {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s", CK_HOST, HA_PORT, CK_HOST);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s", CK_HOST, HA_PORT, HA_HOST);
 
         Exception ex = null;
         container.stop();

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.housepower.jdbc;
+
+import com.github.housepower.log.Logger;
+import com.github.housepower.log.LoggerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FailoverClickhouseConnectionITest extends AbstractITest {
+    private static final Logger LOG = LoggerFactory.getLogger(FailoverClickhouseConnectionITest.class);
+
+    protected static int HA_PORT;
+
+    @Container
+    public static ClickHouseContainer containerHA = (ClickHouseContainer) new ClickHouseContainer(CLICKHOUSE_IMAGE)
+            .withEnv("CLICKHOUSE_USER", CLICKHOUSE_USER)
+            .withEnv("CLICKHOUSE_PASSWORD", CLICKHOUSE_PASSWORD)
+            .withEnv("CLICKHOUSE_DB", CLICKHOUSE_DB);
+
+
+    @BeforeEach
+    public void reset() throws SQLException {
+        resetDriverManager();
+        container.start();
+        containerHA.start();
+
+        CK_PORT = container.getMappedPort(ClickHouseContainer.NATIVE_PORT);
+        HA_PORT = containerHA.getMappedPort(ClickHouseContainer.NATIVE_PORT);
+        LOG.info("Port1 {}, Port2 {}", CK_PORT, HA_PORT);
+    }
+
+    @Test
+    public void testClickhouseDownBeforeConnect() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        container.stop();
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            withStatement(connection, stmt -> {
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforeStatement() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            container.stop();
+            withStatement(connection, stmt -> {
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforePrepareStatement() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            container.stop();
+            withPreparedStatement(connection, "select count() from system.tables", stmt -> {
+                ResultSet rs = stmt.executeQuery();
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforeExecute() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            withStatement(connection, stmt -> {
+                container.stop();
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testClickhouseDownBeforeAndAfterConnect() {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s:%s", CK_HOST, CK_PORT, CK_HOST, HA_PORT);
+
+        Exception ex = null;
+        container.stop();
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default?query_id=xxx", haHost))
+        ) {
+            containerHA.stop();
+            withStatement(connection, stmt -> {
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        } catch (Exception e) {
+            ex = e;
+        }
+
+        assertNotNull(ex);
+    }
+
+    @Test
+    public void testClickhouseAllDownBeforeConnect() throws Exception {
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s", CK_HOST, HA_PORT, CK_HOST);
+
+        Exception ex = null;
+        container.stop();
+        containerHA.stop();
+        try (Connection connection = DriverManager
+                .getConnection(String.format(Locale.ROOT, "jdbc:clickhouse://%s/default", haHost))
+        ) {
+            withStatement(connection, stmt -> {
+
+                ResultSet rs = stmt.executeQuery("select count() from system.tables");
+
+                if (rs.next()) {
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            });
+        } catch (Exception e) {
+            ex = e;
+        }
+
+        assertNotNull(ex);
+    }
+}

--- a/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
+++ b/clickhouse-native-jdbc/src/test/java/com/github/housepower/jdbc/FailoverClickhouseConnectionITest.java
@@ -153,7 +153,7 @@ public class FailoverClickhouseConnectionITest extends AbstractITest {
 
     @Test
     public void testClickhouseAllDownBeforeConnect() throws Exception {
-        String haHost = String.format(Locale.ROOT, "%s:%s,%s", CK_HOST, HA_PORT, HA_HOST);
+        String haHost = String.format(Locale.ROOT, "%s:%s,%s", CK_HOST, CK_PORT, HA_HOST);
 
         Exception ex = null;
         container.stop();


### PR DESCRIPTION
This PR proposes to extend the JDBC URL pattern as follows to support failover.

`jdbc:clickhouse://host1:port1,host2:port2[/database][?prop1=value1&prop2=value2]`

To be clear, do not expect it to act as load balancing, the mechanism of failover is: 
1. try to connect the first host at the beginning
2. if the first host is unreachable, then try the second, and so on
3. when the connection is broken, go 1